### PR TITLE
Improve Text Handling

### DIFF
--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/metadata/DefaultVocabCache.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/metadata/DefaultVocabCache.java
@@ -44,6 +44,11 @@ public class DefaultVocabCache implements VocabCache {
         this.minWordFrequency = minWordFrequency;
     }
 
+    /*
+     * Constructor for use with initialize()
+     */
+    public DefaultVocabCache(){}
+
     @Override
     public void incrementNumDocs(double by) {
         numDocs += by;

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/reader/TfidfRecordReader.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/reader/TfidfRecordReader.java
@@ -89,12 +89,19 @@ public class TfidfRecordReader extends FileRecordReader  {
                     recordLabels.add(new IntWritable(getCurrentLabel()).toInt());
                 records.add(RecordConverter.toRecord(tfidfVectorizer.transform(fileContents)));
             }
-            
+
             labelIter = recordLabels.iterator();
             recordIter = records.iterator();
         }
 
 
+    }
+
+    @Override
+    public void reset() {
+        if(inputSplit == null) throw new UnsupportedOperationException("Cannot reset without first initializing");
+        labelIter = recordLabels.iterator();
+        recordIter = records.iterator();
     }
 
     @Override

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/reader/TfidfRecordReader.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/reader/TfidfRecordReader.java
@@ -42,6 +42,7 @@ public class TfidfRecordReader extends FileRecordReader  {
     private Iterator<Integer> labelIter;
     private Iterator<List<Writable>> recordIter;
     private int numFeatures;
+    private boolean initialized = false;
 
 
     @Override
@@ -94,7 +95,16 @@ public class TfidfRecordReader extends FileRecordReader  {
             recordIter = records.iterator();
         }
 
-
+        if(appendLabel){
+            Iterator<List<Writable>> rIter = records.iterator();
+            Iterator<Integer> lIter = recordLabels.iterator();
+            while(rIter.hasNext()){
+                List<Writable> record = rIter.next();
+                Integer label = lIter.next();
+                record.add(new IntWritable(label));
+            }
+        }
+        this.initialized = true;
     }
 
     @Override
@@ -109,9 +119,6 @@ public class TfidfRecordReader extends FileRecordReader  {
         if(recordIter == null)
             return super.next();
         List<Writable> record = recordIter.next();
-        if(appendLabel) {
-            record.add(new IntWritable(labelIter.next()));
-        }
         return record;
     }
 
@@ -143,6 +150,9 @@ public class TfidfRecordReader extends FileRecordReader  {
     }
 
     public void setTfidfVectorizer(TfidfVectorizer tfidfVectorizer) {
+        if(initialized){
+            throw new IllegalArgumentException("Setting TfidfVectorizer after TfidfRecordReader initialization doesn't have an effect");
+        }
         this.tfidfVectorizer = tfidfVectorizer;
     }
 

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/reader/TfidfRecordReader.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/reader/TfidfRecordReader.java
@@ -159,5 +159,14 @@ public class TfidfRecordReader extends FileRecordReader  {
     public int getNumFeatures() {
         return numFeatures;
     }
+
+    public void shuffle(){
+        this.shuffle(new Random());
+    }
+
+    public void shuffle(Random random){
+        Collections.shuffle(this.records, random);
+        this.reset();
+    }
 }
 

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/tokenization/tokenizer/UimaTokenizer.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/tokenization/tokenizer/UimaTokenizer.java
@@ -38,7 +38,7 @@ public class UimaTokenizer implements Tokenizer {
     private int index;
     private static Logger log = LoggerFactory.getLogger(UimaTokenizer.class);
     private boolean checkForLabel;
-
+    private TokenPreProcess tokenPreProcessor;
 
 
     public UimaTokenizer(String tokens, UimaResource resource, boolean checkForLabel) {
@@ -94,6 +94,9 @@ public class UimaTokenizer implements Tokenizer {
     public String nextToken() {
         String ret = tokens.get(index);
         index++;
+        if(tokenPreProcessor != null){
+            ret = tokenPreProcessor.preProcess(ret);
+        }
         return ret;
     }
 
@@ -108,9 +111,8 @@ public class UimaTokenizer implements Tokenizer {
 
 	@Override
 	public void setTokenPreProcessor(TokenPreProcess tokenPreProcessor) {
-		// TODO Auto-generated method stub
-		
-	}
+        this.tokenPreProcessor = tokenPreProcessor;
+    }
 
 
 

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/AbstractTfidfVectorizer.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/AbstractTfidfVectorizer.java
@@ -42,6 +42,7 @@ public abstract class AbstractTfidfVectorizer<VECTOR_TYPE> extends TextVectorize
             if(!seen.contains(token)) {
                 cache.incrementDocCount(token);
             }
+            seen.add(token);
         }
     }
 

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/AbstractTfidfVectorizer.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/AbstractTfidfVectorizer.java
@@ -38,11 +38,13 @@ public abstract class AbstractTfidfVectorizer<VECTOR_TYPE> extends TextVectorize
         Set<String> seen = new HashSet<>();
         while(tokenizer.hasMoreTokens()) {
             String token = tokenizer.nextToken();
-            cache.incrementCount(token);
-            if(!seen.contains(token)) {
-                cache.incrementDocCount(token);
+            if(!stopWords.contains(token)) {
+                cache.incrementCount(token);
+                if (!seen.contains(token)) {
+                    cache.incrementDocCount(token);
+                }
+                seen.add(token);
             }
-            seen.add(token);
         }
     }
 

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/TextVectorizer.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/TextVectorizer.java
@@ -21,11 +21,11 @@ import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.vector.Vectorizer;
 import org.datavec.api.writable.Writable;
-import org.datavec.nlp.tokenization.tokenizerfactory.TokenizerFactory;
 import org.datavec.nlp.metadata.DefaultVocabCache;
 import org.datavec.nlp.metadata.VocabCache;
 import org.datavec.nlp.stopwords.StopWords;
 import org.datavec.nlp.tokenization.tokenizer.Tokenizer;
+import org.datavec.nlp.tokenization.tokenizerfactory.TokenizerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -45,6 +45,7 @@ public abstract class TextVectorizer<VECTOR_TYPE> implements Vectorizer<VECTOR_T
     public final static String MIN_WORD_FREQUENCY = "org.nd4j.nlp.minwordfrequency";
     public final static String STOP_WORDS = "org.nd4j.nlp.stopwords";
     public final static String TOKENIZER = "org.datavec.nlp.tokenizerfactory";
+    public final static String VOCAB_CACHE = "org.datavec.nlp.vocabcache";
     protected Collection<String> stopWords;
     protected VocabCache cache;
 
@@ -55,8 +56,15 @@ public abstract class TextVectorizer<VECTOR_TYPE> implements Vectorizer<VECTOR_T
         stopWords = conf.getStringCollection(STOP_WORDS);
         if(stopWords == null || stopWords.isEmpty())
             stopWords = StopWords.getStopWords();
-        cache = new DefaultVocabCache(minWordFrequency);
 
+        String clazz = conf.get(VOCAB_CACHE,DefaultVocabCache.class.getName());
+        try {
+            Class<? extends VocabCache> tokenizerFactoryClazz = (Class<? extends VocabCache>) Class.forName(clazz);
+            cache = tokenizerFactoryClazz.newInstance();
+            cache.initialize(conf);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/TfidfVectorizer.java
+++ b/datavec-data/datavec-data-nlp/src/main/java/org/datavec/nlp/vectorizer/TfidfVectorizer.java
@@ -18,11 +18,10 @@ package org.datavec.nlp.vectorizer;
 
 
 import org.datavec.api.berkeley.Counter;
-import org.datavec.api.writable.IntWritable;
 import org.datavec.api.records.reader.RecordReader;
+import org.datavec.api.writable.IntWritable;
 import org.datavec.api.writable.Writable;
 import org.datavec.nlp.reader.TfidfRecordReader;
-import org.datavec.nlp.vectorizer.AbstractTfidfVectorizer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -39,14 +38,13 @@ import java.util.List;
 public class TfidfVectorizer extends AbstractTfidfVectorizer<INDArray> {
     @Override
     public INDArray createVector(Object[] args) {
-        INDArray ret = Nd4j.create(cache.vocabWords().size());
         Counter<String> docFrequencies = (Counter<String>)args[0];
+        double[] vector = new double[cache.vocabWords().size()];
         for(int i = 0; i < cache.vocabWords().size(); i++) {
             double freq = docFrequencies.getCount(cache.wordAt(i));
-            double tfidf = cache.tfidf(cache.wordAt(i),freq);
-            ret.putScalar(i,tfidf);
+            vector[i] = cache.tfidf(cache.wordAt(i),freq);
         }
-        return ret;
+        return Nd4j.create(vector);
     }
 
     @Override


### PR DESCRIPTION
This Pull Request addresses 4 problems with the TfidfRecordReader:
* It allows TfidfRecordReader to be reset in order to be able to iterate multiple times over the RecordReaderDataSetIterator that is created from it
* It corrects the tfidf calculation by fixing a bug where tokens where counted multiple times per document
* It improves performance by moving only complete tfidf arrays over to ND4J instead of running `.putScalar` for each element
* It actually respects StopWords for tfidf

And it improves some other areas around vectorizing text with datavec
* It actually uses the preprocessor set on UimaTokenizer
* It allows to configure a custom VocabCache, e.g. if you want to implement a version that also has a MAX_WORD_FREQUENCY