### PR TITLE
Remove unneeded normalize value

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/BaseRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/BaseRecordReader.java
@@ -49,4 +49,5 @@ public abstract class BaseRecordReader implements RecordReader {
     public void setListeners(RecordListener... listeners) {
         setListeners(Arrays.asList(listeners));
     }
+
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
@@ -75,7 +75,7 @@ public abstract class BaseInputSplit implements InputSplit {
     public InputSplit[] sample(PathFilter pathFilter, double... weights) {
         URI[] paths = pathFilter != null ? pathFilter.filter(locations()) : locations();
 
-        if (weights != null && weights.length > 0) {
+        if (weights != null && weights.length > 0 && weights[0] != 1.0) {
             InputSplit[] splits = new InputSplit[weights.length];
             double totalWeight = 0;
             for (int i = 0; i < weights.length; i++) {

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/BaseImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/BaseImageLoader.java
@@ -46,8 +46,6 @@ public abstract class BaseImageLoader implements Serializable {
     protected int width = -1;
     protected int channels = -1;
     protected boolean centerCropIfNeeded = false;
-    protected double normalizeValue = 0.0;
-    protected boolean normalizeIfNeeded = false;
     protected ImageTransform imageTransform = null;
 
     public String[] getAllowedFormats() {

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/CifarLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/CifarLoader.java
@@ -202,13 +202,13 @@ public class CifarLoader extends NativeImageLoader implements Serializable {
                 DataSet result = convertDataSet(numToConvertDS);
                 result.save(new File(trainFilesSerialized + i + ".ser"));
             }
-            for (int i = 1; i <= (TRAINFILENAMES.length); i++){
-                normalizeCifar(new File(trainFilesSerialized + i + ".ser"));
-            }
+//            for (int i = 1; i <= (TRAINFILENAMES.length); i++){
+//                normalizeCifar(new File(trainFilesSerialized + i + ".ser"));
+//            }
             inputStream = testInputStream;
             DataSet result = convertDataSet(numToConvertDS);
             result.save(new File(testFilesSerialized));
-            normalizeCifar(new File(testFilesSerialized));
+//            normalizeCifar(new File(testFilesSerialized));
         }
         setInputStream();
     }
@@ -311,9 +311,9 @@ public class CifarLoader extends NativeImageLoader implements Serializable {
             imageData.put(3 * i + 1, byteFeature[i + 1 + height * width]); // green
             imageData.put(3 * i + 2, byteFeature[i + 1]); // red
         }
-        if (useSpecialPreProcessCifar) {
-            image = convertCifar(image);
-        }
+//        if (useSpecialPreProcessCifar) {
+//            image = convertCifar(image);
+//        }
 
         return new Pair<>(label, image);
     }
@@ -357,6 +357,7 @@ public class CifarLoader extends NativeImageLoader implements Serializable {
                     vTempMean = vChannel.mean(new int[] {0,2,3}).getDouble(0);
                     vStd += varManual(vChannel, vTempMean);
                     vMean += vTempMean;
+                    data.setFeatures(data.getFeatureMatrix().div(255));
                 } else {
                     // normalize if just input stream and not special preprocess
                     data.setFeatures(data.getFeatureMatrix().div(255));

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/CifarLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/CifarLoader.java
@@ -194,7 +194,7 @@ public class CifarLoader extends NativeImageLoader implements Serializable {
             e.printStackTrace();
         }
 
-        defineLabels();
+        if(labels.isEmpty()) defineLabels();
 
         if (useSpecialPreProcessCifar && train && !cifarProcessedFilesExists()) {
             for (int i = fileNum+1; i <= (TRAINFILENAMES.length); i++) {
@@ -436,6 +436,8 @@ public class CifarLoader extends NativeImageLoader implements Serializable {
         train = false;
         setInputStream();
         shuffle = false;
+        numExamples = 0;
+        fileNum = 0;
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/LFWLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/LFWLoader.java
@@ -78,19 +78,18 @@ public class LFWLoader extends BaseImageLoader implements Serializable {
     public LFWLoader(){this(false);}
 
     public LFWLoader(boolean useSubset){
-        this(new int[] {HEIGHT, WIDTH, CHANNELS,}, null, 0, useSubset);
+        this(new int[] {HEIGHT, WIDTH, CHANNELS,}, null, useSubset);
     }
 
     public LFWLoader(int[] imgDim, boolean useSubset){
-        this(imgDim, null, 0, useSubset);
+        this(imgDim, null, useSubset);
     }
 
-    public LFWLoader(int[] imgDim, ImageTransform imgTransform, int normalizeValue, boolean useSubset){
+    public LFWLoader(int[] imgDim, ImageTransform imgTransform, boolean useSubset){
         this.height = imgDim[0];
         this.width = imgDim[1];
         this.channels = imgDim[2];
         this.imageTransform  = imgTransform;
-        this.normalizeValue = normalizeValue;
         this.useSubset = useSubset;
         this.localDir = useSubset? localSubDir: localDir;
         this.fullDir = new File(BASE_DIR, localDir);
@@ -178,7 +177,7 @@ public class LFWLoader extends BaseImageLoader implements Serializable {
 
     public RecordReader getRecordReader(int batchSize, int numExamples, int[]imgDim, int numLabels, PathLabelGenerator labelGenerator, boolean train, double splitTrainTest, Random rng) {
         load(batchSize, numExamples, numLabels, labelGenerator, splitTrainTest, rng);
-        RecordReader recordReader = new ImageRecordReader(imgDim[0], imgDim[1], imgDim[2], labelGenerator, imageTransform, normalizeValue);
+        RecordReader recordReader = new ImageRecordReader(imgDim[0], imgDim[1], imgDim[2], labelGenerator, imageTransform);
 
         try {
             InputSplit data = train? inputSplit[0]: inputSplit[1];

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -114,23 +114,6 @@ public class NativeImageLoader extends BaseImageLoader {
         this.converter = new OpenCVFrameConverter.ToMat();
     }
 
-
-    /**
-     * Instantiate an image with the given
-     * height and width
-     * @param height the height to load
-     * @param width  the width to load
-     * @param channels the number of channels for the image*
-     * @param imageTransform to use before rescaling and converting
-     * @param normalizeValue after rescaling and converting
-     */
-    public NativeImageLoader(int height, int width, int channels, ImageTransform imageTransform, double normalizeValue) {
-        this(height, width, channels, imageTransform);
-        normalizeIfNeeded = (normalizeValue > 0)? true: false;
-        this.normalizeValue = normalizeValue;
-        this.converter = new OpenCVFrameConverter.ToMat();
-    }
-
     @Override
     public String[] getAllowedFormats() {
         return ALLOWED_FORMATS;
@@ -363,14 +346,7 @@ public class NativeImageLoader extends BaseImageLoader {
             }
         }
         image.data(); // dummy call to make sure it does not get deallocated prematurely
-        if (normalizeIfNeeded) {
-            ret = normalizeIfNeeded(ret);
-        }
         return ret.reshape(ArrayUtil.combine(new int[]{1},ret.shape()));
-    }
-
-    protected INDArray normalizeIfNeeded(INDArray image){
-        return image.div(normalizeValue);
     }
 
     // TODO build flexibility on where to crop the image

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -73,17 +73,16 @@ public abstract class BaseImageRecordReader extends BaseRecordReader implements 
     }
 
     public BaseImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator) {
-        this(height, width, channels,labelGenerator, null, 0.0);
+        this(height, width, channels,labelGenerator, null);
     }
 
-    public BaseImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator, ImageTransform imageTransform, double normalizeValue) {
+    public BaseImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator, ImageTransform imageTransform) {
         this.height = height;
         this.width = width;
         this.channels = channels;
         this.labelGenerator = labelGenerator;
         this.imageTransform = imageTransform;
         this.appendLabel = labelGenerator !=null? true: false;
-        this.normalizeValue = normalizeValue;
     }
 
     protected boolean containsFormat(String format) {
@@ -97,7 +96,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader implements 
     @Override
     public void initialize(InputSplit split) throws IOException {
         if (imageLoader == null) {
-            imageLoader = new NativeImageLoader(height, width, channels, imageTransform, normalizeValue);
+            imageLoader = new NativeImageLoader(height, width, channels, imageTransform);
         }
         inputSplit = split;
         Collection<File> allFiles;
@@ -155,7 +154,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader implements 
         if ("imageio".equals(conf.get(IMAGE_LOADER))) {
             this.imageLoader = new ImageLoader(height, width, channels, cropImage);
         } else {
-            this.imageLoader = new NativeImageLoader(height, width, channels, imageTransform, normalizeValue);
+            this.imageLoader = new NativeImageLoader(height, width, channels, imageTransform);
         }
         this.conf = conf;
         initialize(split);

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/ImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/ImageRecordReader.java
@@ -43,34 +43,19 @@ public class ImageRecordReader extends BaseImageRecordReader {
         super(height, width, channels, labelGenerator);
     }
 
-    /** Loads images with given height, width, and channels, appending labels returned by the generator. */
-    public ImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator, double normalizeValue) {
-        super(height, width, channels, labelGenerator, null, normalizeValue);
-    }
-
     /** Loads images with given height, width, and channels, appending no labels. */
     public ImageRecordReader(int height, int width, int channels) {
         super(height, width, channels, (PathLabelGenerator) null);
     }
 
-    /** Loads images with given height, width, and channels, appending no labels. */
-    public ImageRecordReader(int height, int width, int channels, double normalizeValue) {
-        super(height, width, channels, null, null, normalizeValue);
-    }
-
     /** Loads images with given height, width, and channels, appending labels returned by the generator. */
     public ImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator, ImageTransform imageTransform) {
-        super(height, width, channels, labelGenerator, imageTransform, 0.0);
+        super(height, width, channels, labelGenerator, imageTransform);
     }
 
     /** Loads images with given height, width, and channels, appending no labels. */
     public ImageRecordReader(int height, int width, int channels, ImageTransform imageTransform) {
-        super(height, width, channels, null, imageTransform, 0.0);
-    }
-
-    /** Loads images with given height, width, and channels, appending labels returned by the generator. */
-    public ImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator, ImageTransform imageTransform, double normalizeValue) {
-        super(height, width, channels, labelGenerator, imageTransform, normalizeValue);
+        super(height, width, channels, null, imageTransform);
     }
 
     /** Loads images with given  height, width, and channels, appending labels returned by the generator. */
@@ -80,7 +65,7 @@ public class ImageRecordReader extends BaseImageRecordReader {
 
     /** Loads images with given height, width, and channels = 1, appending no labels. */
     public ImageRecordReader(int height, int width) {
-        super(height, width,  1, null, null, 0.0);
+        super(height, width,  1, null, null);
     }
 
 

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -158,17 +158,6 @@ public class TestNativeImageLoader {
         assertEquals(img2.channels(), cropped2.channels());
     }
 
-    @Test
-    public void testNormalizeIfNeeded() throws Exception {
-        int normVal = 255;
-        int w1 = 6, h1 = 10, ch1 = 1;
-        NativeImageLoader loader = new NativeImageLoader(h1, w1, ch1, null, normVal);
-
-        INDArray imgExample = Nd4j.linspace(0, 59, 60);
-        INDArray actualResult = loader.normalizeIfNeeded(imgExample);
-        INDArray expectedResult = imgExample.div(normVal);
-        assertEquals(expectedResult, actualResult);
-    }
 
     Mat makeRandomImage(int height, int width, int channels) {
         if (height <= 0) {


### PR DESCRIPTION
Use preprocessor to normalize
Added check for BaseInputSplit to avoid split data when 100% is expected to be in 1 split.