### PR TITLE
Adds a few rules from the maven-lint plugin to check for redundant/dup deps.

### DIFF
--- a/datavec-api/pom.xml
+++ b/datavec-api/pom.xml
@@ -79,12 +79,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-            <version>${junit.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>3.2.5.RELEASE</version>

--- a/datavec-data/datavec-data-codec/pom.xml
+++ b/datavec-data/datavec-data-codec/pom.xml
@@ -45,11 +45,6 @@
         </dependency>
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-api</artifactId>
-            <version>${nd4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
             <artifactId>nd4j-native</artifactId>
             <version>${nd4j.version}</version>
             <scope>test</scope>

--- a/datavec-hadoop/pom.xml
+++ b/datavec-hadoop/pom.xml
@@ -31,20 +31,20 @@
             <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
         </repository>
     </repositories>
-	<!-- we'll change this to something more valid later, just prototyping for now -->
-	<properties>
+        <!-- we'll change this to something more valid later, just prototyping for now -->
+        <properties>
         <hadoop.version>2.0.0-cdh4.6.0</hadoop.version>
     </properties>
-    
+
     <dependencies>
-    
+
         <dependency>
             <groupId>org.datavec</groupId>
             <artifactId>datavec-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-    
-    
+
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
@@ -66,12 +66,6 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
@@ -82,8 +76,8 @@
             <version>3.2.5.RELEASE</version>
             <scope>test</scope>
         </dependency>
-        
- 		<dependency>
+
+                <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
@@ -111,7 +105,7 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
-        </dependency>        
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,32 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+              <groupId>com.lewisd</groupId>
+              <artifactId>lint-maven-plugin</artifactId>
+              <version>0.0.8</version>
+              <configuration>
+                <failOnViolation>true</failOnViolation>
+                <onlyRunRules>
+                  <rule>DuplicateDep</rule>
+                  <rule>RedundantDepVersion</rule>
+                  <rule>RedundantPluginVersion</rule>
+                  <rule>VersionProp</rule>
+                  <rule>DotVersionProperty</rule>
+                </onlyRunRules>
+                <xmlOutputFile>${project.build.directory}/maven-lint-result.xml</xmlOutputFile>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>pom-lint</id>
+                  <phase>validate</phase>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+
         </plugins>
 
     </build>


### PR DESCRIPTION
Helps with issues such as nd4j/#1345.

Please consider testing since this removes the hardcoding of a few versions.