### PR TITLE
deprecate connect factory for spark

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/column/RemoveColumnsTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/column/RemoveColumnsTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.column;
 
+import org.datavec.api.util.StringUtils;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.datavec.api.transform.schema.Schema;
@@ -92,8 +93,12 @@ public class RemoveColumnsTransform extends BaseTransform {
     @Override
     public List<Writable> map(List<Writable> writables) {
         if (writables.size() != inputSchema.numColumns()) {
+            List<String> list = new ArrayList<>();
+            for(Writable w : writables)
+                list.add(w.toString());
+            String toString = StringUtils.join(",",list);
             throw new IllegalStateException("Cannot execute transform: input writables list length (" + writables.size() + ") does not " +
-                    "match expected number of elements (schema: " + inputSchema.numColumns() + "). Transform = " + toString());
+                    "match expected number of elements (schema: " + inputSchema.numColumns() + "). Transform = " + toString() + " and record " + toString);
         }
 
         List<Writable> outList = new ArrayList<>(writables.size() - columnsToRemove.length);

--- a/datavec-spark/src/main/java/org/datavec/spark/SequenceEmptyRecordFunction.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/SequenceEmptyRecordFunction.java
@@ -1,0 +1,18 @@
+package org.datavec.spark;
+
+import org.apache.spark.api.java.function.Function;
+import org.datavec.api.writable.Writable;
+
+import java.util.List;
+
+/**
+ * Used for filtering empty records
+ *
+ * @author Adam Gibson
+ */
+public class SequenceEmptyRecordFunction implements Function<List<List<Writable>>,Boolean>{
+    @Override
+    public Boolean call(List<List<Writable>> v1) throws Exception {
+        return v1.isEmpty();
+    }
+}

--- a/datavec-spark/src/main/java/org/datavec/spark/functions/EmptyRecordFunction.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/functions/EmptyRecordFunction.java
@@ -1,0 +1,18 @@
+package org.datavec.spark.functions;
+
+import org.apache.spark.api.java.function.Function;
+import org.datavec.api.writable.Writable;
+
+import java.util.List;
+
+/**
+ * Used for filtering empty records
+ *
+ * @author Adam Gibson
+ */
+public class EmptyRecordFunction  implements Function<List<Writable>,Boolean>{
+    @Override
+    public Boolean call(List<Writable> v1) throws Exception {
+        return v1.isEmpty();
+    }
+}

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/transform/SparkTransformFunction.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/transform/SparkTransformFunction.java
@@ -17,22 +17,34 @@
 package org.datavec.spark.transform.transform;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.api.java.function.Function;
 import org.datavec.api.writable.Writable;
 import org.datavec.api.transform.Transform;
+import org.datavec.spark.transform.SparkTransformExecutor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Created by Alex on 5/03/2016.
  */
 @AllArgsConstructor
+@Slf4j
 public class SparkTransformFunction implements Function<List<Writable>,List<Writable>> {
 
     private final Transform transform;
 
     @Override
     public List<Writable> call(List<Writable> v1) throws Exception {
+        if(SparkTransformExecutor.isTryCatch()) {
+          try {
+              return transform.map(v1);
+          }catch (Exception e) {
+              log.warn("Error occurred " + e + " on record " + v1);
+              return new ArrayList<>();
+          }
+        }
         return transform.map(v1);
     }
 }

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/utils/SparkConnectFactory.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/utils/SparkConnectFactory.java
@@ -22,6 +22,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 /**
  * Factory to create spark connections
  */
+@Deprecated
 public class SparkConnectFactory {
 
     public static String name = "SparkConnectFactory";


### PR DESCRIPTION
Adds empty record mode for debugging data pipelines. Also deprecates the spark connect factory.