### PR TITLE
Add TransformSplit class to map one InputSplit to another one

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/split/TransformSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/TransformSplit.java
@@ -1,0 +1,81 @@
+package org.datavec.api.split;
+
+import lombok.NonNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * InputSplit implementation that maps the URIs of a given BaseInputSplit to new URIs. Useful when features and labels
+ * are in different files sharing a common naming scheme, and the name of the output file can be determined given the
+ * name of the input file.
+ *
+ * @author Ede Meijer
+ */
+public class TransformSplit extends BaseInputSplit {
+    private final BaseInputSplit sourceSplit;
+    private final URITransform transform;
+
+    /**
+     * Apply a given transformation to the raw URI objects
+     *
+     * @param sourceSplit the split with URIs to transform
+     * @param transform transform operation that returns a new URI based on an input URI
+     * @throws URISyntaxException thrown if the transformed URI is malformed
+     */
+    public TransformSplit(
+        @NonNull BaseInputSplit sourceSplit,
+        @NonNull URITransform transform
+    ) throws URISyntaxException {
+        this.sourceSplit = sourceSplit;
+        this.transform = transform;
+        initialize();
+    }
+
+    /**
+     * Static factory method, replace the string version of the URI with a simple search-replace pair
+     *
+     * @param sourceSplit the split with URIs to transform
+     * @param search the string to search
+     * @param replace the string to replace with
+     * @throws URISyntaxException thrown if the transformed URI is malformed
+     */
+    public static TransformSplit ofSearchReplace(
+        @NonNull BaseInputSplit sourceSplit,
+        @NonNull String search,
+        @NonNull String replace
+    ) throws URISyntaxException {
+        return new TransformSplit(sourceSplit, new URITransform() {
+            @Override
+            public URI apply(URI uri) throws URISyntaxException {
+                return new URI(uri.toString().replace(search, replace));
+            }
+        });
+    }
+
+    private void initialize() throws URISyntaxException {
+        length = sourceSplit.length();
+        locations = new URI[sourceSplit.locations().length];
+        URI[] sourceLocations = sourceSplit.locations();
+        for (int i = 0; i < sourceLocations.length; i++) {
+            locations[i] = transform.apply(sourceLocations[i]);
+        }
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+
+    }
+
+    public interface URITransform {
+        URI apply(URI uri) throws URISyntaxException;
+    }
+}

--- a/datavec-api/src/test/java/org/datavec/api/split/TransformSplitTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/TransformSplitTest.java
@@ -1,0 +1,51 @@
+package org.datavec.api.split;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * @author Ede Meijer
+ */
+public class TransformSplitTest {
+    @Test
+    public void testTransform() throws URISyntaxException {
+        Collection<URI> inputFiles = asList(new URI("file:///foo/bar/../0.csv"), new URI("file:///foo/1.csv"));
+
+        InputSplit SUT = new TransformSplit(
+            new CollectionInputSplit(inputFiles),
+            new TransformSplit.URITransform() {
+                @Override
+                public URI apply(URI uri) throws URISyntaxException {
+                    return uri.normalize();
+                }
+            }
+        );
+
+        assertArrayEquals(
+            new URI[]{new URI("file:///foo/0.csv"), new URI("file:///foo/1.csv")},
+            SUT.locations()
+        );
+    }
+
+    @Test
+    public void testSearchReplace() throws URISyntaxException {
+        Collection<URI> inputFiles = asList(new URI("file:///foo/1-in.csv"), new URI("file:///foo/2-in.csv"));
+
+        InputSplit SUT = TransformSplit.ofSearchReplace(
+            new CollectionInputSplit(inputFiles),
+            "-in.csv",
+            "-out.csv"
+        );
+
+        assertArrayEquals(
+            new URI[]{new URI("file:///foo/1-out.csv"), new URI("file:///foo/2-out.csv")},
+            SUT.locations()
+        );
+    }
+}


### PR DESCRIPTION
I have a use case where I need my inputs and outputs in separate files because I'm dealing with time series and outputs of different lengths. There was no way to pair two FileSplits into a single iterator because the order of the files is not deterministic.

This utility solves the problem by transforming the URIs of one split into different URIs. Based on any custom naming scheme, one can then create a split of output files based on the input files in the same order, so it even works when the input split it shuffled.