### PR TITLE
Columntransformnames

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/transform/ColumnOp.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/ColumnOp.java
@@ -1,0 +1,41 @@
+package org.datavec.api.transform;
+
+/**
+ * ColumnOp
+ * is a transform meant
+ * to run over 1 or more columns
+ *
+ * @author Adam Gibson
+ */
+public interface ColumnOp {
+
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     * @return the output column name
+     */
+    String outputColumnName();
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     * @return the output column names
+     */
+    String[] outputColumnNames();
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     * @return
+     */
+    String[] columnNames();
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     * @return
+     */
+    String columnName();
+
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/DataAction.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/DataAction.java
@@ -96,12 +96,12 @@ public class DataAction implements Serializable {
         return "DataAction(" + str + ")";
     }
 
-    public Schema getSchema(){
+    public Schema getSchema() {
         if(transform != null){
             return transform.getInputSchema();
-        } else if(filter != null){
+        } else if(filter != null) {
             return filter.getInputSchema();
-        } else if(convertToSequence != null){
+        } else if(convertToSequence != null) {
             return convertToSequence.getInputSchema();
         } else if(convertFromSequence != null){
             return convertFromSequence.getInputSchema();

--- a/datavec-api/src/main/java/org/datavec/api/transform/ReduceOp.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/ReduceOp.java
@@ -33,7 +33,8 @@ import org.datavec.api.transform.reduce.Reducer;
  * TakeFirst: Take the first possible  value in the list<br>
  * TakeLast: Take the last possible value in the list<br>
  *
- * <b>Note</b>: For custom reduction operations with {@link Reducer}, use the {@link ColumnReduction}
+ * <b>Note</b>: For custom reduction operations with {@link Reducer}
+ * , use the {@link ColumnReduction}
  * functionality.
  *
  * @author Alex Black

--- a/datavec-api/src/main/java/org/datavec/api/transform/Transform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/Transform.java
@@ -94,8 +94,18 @@ public interface Transform extends Serializable {
      */
     void setInputSchema(Schema inputSchema);
 
+    /**
+     * Getter for input schema
+     * @return
+     */
     Schema getInputSchema();
 
+    /**
+     * Transform a writable
+     * in to another writable
+     * @param writables the record to transform
+     * @return the transformed writable
+     */
     List<Writable> map(List<Writable> writables);
 
     /** Transform a sequence */

--- a/datavec-api/src/main/java/org/datavec/api/transform/TransformProcess.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/TransformProcess.java
@@ -69,7 +69,9 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A TransformProcess defines an ordered list of transformations to be executed on some data
+ * A TransformProcess defines
+ * an ordered list of transformations
+ * to be executed on some data
  *
  * @author Alex Black
  */
@@ -79,7 +81,7 @@ public class TransformProcess implements Serializable {
     private final Schema initialSchema;
     private List<DataAction> actionList;
 
-    public TransformProcess(@JsonProperty("initialSchema") Schema initialSchema, @JsonProperty("actionList") List<DataAction> actionList){
+    public TransformProcess(@JsonProperty("initialSchema") Schema initialSchema, @JsonProperty("actionList") List<DataAction> actionList) {
         this.initialSchema = initialSchema;
         this.actionList = actionList;
 
@@ -220,6 +222,11 @@ public class TransformProcess implements Serializable {
         return currValues;
     }
 
+    /**
+     *
+     * @param input
+     * @return
+     */
     public List<List<Writable>> executeSequenceToSequence(List<List<Writable>> input) {
         List<List<Writable>> currValues = input;
 

--- a/datavec-api/src/main/java/org/datavec/api/transform/condition/column/BaseColumnCondition.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/condition/column/BaseColumnCondition.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.condition.column;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import lombok.EqualsAndHashCode;
 import org.datavec.api.transform.condition.SequenceConditionMode;
@@ -32,7 +33,7 @@ import java.util.List;
  */
 @JsonIgnoreProperties({"columnIdx","schema","sequenceMode"})
 @EqualsAndHashCode(exclude = {"columnIdx","schema","sequenceMode"})
-public abstract class BaseColumnCondition implements Condition {
+public abstract class BaseColumnCondition implements Condition,ColumnOp {
 
     public static final SequenceConditionMode DEFAULT_SEQUENCE_CONDITION_MODE = SequenceConditionMode.Or;
 
@@ -83,6 +84,28 @@ public abstract class BaseColumnCondition implements Condition {
             default:
                 throw new RuntimeException("Unknown/not implemented sequence mode: " + sequenceMode);
         }
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return new String[] {columnName};
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
     }
 
     public abstract boolean columnCondition(Writable writable);

--- a/datavec-api/src/main/java/org/datavec/api/transform/condition/column/BaseColumnCondition.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/condition/column/BaseColumnCondition.java
@@ -87,6 +87,28 @@ public abstract class BaseColumnCondition implements Condition,ColumnOp {
     }
 
     /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return columnName();
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return columnNames();
+    }
+
+    /**
      * Returns column names
      * this op is meant to run on
      *

--- a/datavec-api/src/main/java/org/datavec/api/transform/metadata/ColumnMetaData.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/metadata/ColumnMetaData.java
@@ -49,6 +49,10 @@ public interface ColumnMetaData extends Serializable, Cloneable {
      */
     String getName();
 
+    /**
+     * Setter for the name
+     * @param name
+     */
     void setName(String name);
 
     /**

--- a/datavec-api/src/main/java/org/datavec/api/transform/reduce/ColumnReduction.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/reduce/ColumnReduction.java
@@ -32,7 +32,9 @@ public interface ColumnReduction extends Serializable {
 
     /**
      * Reduce a single column.
-     * <b>Note</b>: The {@code List<Writable>} here is a single <b>column</b> in a reduction window, and NOT the single row
+     * <b>Note</b>: The {@code List<Writable>}
+     * here is a single <b>column</b> in a reduction window,
+     * and NOT the single row
      * (as is usually the case for {@code List<Writable>} instances
      *
      * @param columnData The Writable objects for a column

--- a/datavec-api/src/main/java/org/datavec/api/transform/sequence/comparator/BaseColumnComparator.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/sequence/comparator/BaseColumnComparator.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.sequence.comparator;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import lombok.EqualsAndHashCode;
 import org.datavec.api.transform.schema.Schema;
@@ -29,7 +30,7 @@ import java.util.List;
  */
 @EqualsAndHashCode(exclude = {"schema", "columnIdx"})
 @JsonIgnoreProperties({"schema", "columnIdx"})
-public abstract class BaseColumnComparator implements SequenceComparator {
+public abstract class BaseColumnComparator implements SequenceComparator,ColumnOp {
 
     protected Schema schema;
 
@@ -56,4 +57,26 @@ public abstract class BaseColumnComparator implements SequenceComparator {
     }
 
     protected abstract int compare(Writable w1, Writable w2);
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return new String[] {columnName};
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
+    }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/sequence/comparator/BaseColumnComparator.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/sequence/comparator/BaseColumnComparator.java
@@ -59,6 +59,28 @@ public abstract class BaseColumnComparator implements SequenceComparator,ColumnO
     protected abstract int compare(Writable w1, Writable w2);
 
     /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return columnName();
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return columnNames();
+    }
+
+    /**
      * Returns column names
      * this op is meant to run on
      *

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/BaseColumnTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/BaseColumnTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.datavec.api.transform.metadata.ColumnMetaData;
 import org.datavec.api.transform.schema.Schema;
@@ -26,12 +27,14 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-/**Map the values in a single column to new values.
- * For example: string -> string, or empty -> x type transforms for a single column
+/**
+ * Map the values in a single column to new values.
+ * For example: string -> string, or empty -> x type
+ * transforms for a single column
  */
 @Data
 @JsonIgnoreProperties({"inputSchema","columnNumber"})
-public abstract class BaseColumnTransform extends BaseTransform {
+public abstract class BaseColumnTransform extends BaseTransform implements ColumnOp {
 
     protected final String columnName;
     protected int columnNumber = -1;
@@ -56,7 +59,7 @@ public abstract class BaseColumnTransform extends BaseTransform {
         Iterator<ColumnMetaData> typesIter = oldMeta.iterator();
 
         int i=0;
-        while(typesIter.hasNext()){
+        while(typesIter.hasNext()) {
             ColumnMetaData t = typesIter.next();
             if(i++ == columnNumber){
                 newMeta.add(getNewColumnMetaData(t.getName(), t));
@@ -72,7 +75,7 @@ public abstract class BaseColumnTransform extends BaseTransform {
 
     @Override
     public List<Writable> map(List<Writable> writables) {
-        if(writables.size() != inputSchema.numColumns() ){
+        if(writables.size() != inputSchema.numColumns()) {
             throw new IllegalStateException("Cannot execute transform: input writables list length (" + writables.size() + ") does not " +
                     "match expected number of elements (schema: " + inputSchema.numColumns() + "). Transform = " + toString());
         }
@@ -93,6 +96,50 @@ public abstract class BaseColumnTransform extends BaseTransform {
     }
 
 
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return outputColumnNames()[0];
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return new String[] {columnName};
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return new String[] {columnName};
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
+    }
 
     public abstract Writable map(Writable columnWritable);
 

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/BaseColumnsMathOpTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/BaseColumnsMathOpTransform.java
@@ -16,6 +16,8 @@
 
 package org.datavec.api.transform.transform;
 
+import lombok.Data;
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonInclude;
 import lombok.EqualsAndHashCode;
@@ -53,7 +55,8 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties({"columnIdxs","inputSchema"})
 @EqualsAndHashCode(exclude = {"columnIdxs","inputSchema"})
-public abstract class BaseColumnsMathOpTransform implements Transform {
+@Data
+public abstract class BaseColumnsMathOpTransform implements Transform,ColumnOp {
 
     protected final String newColumnName;
     protected final MathOp mathOp;
@@ -149,6 +152,50 @@ public abstract class BaseColumnsMathOpTransform implements Transform {
             out.add(map(step));
         }
         return out;
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return newColumnName;
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return new String[]{newColumnName};
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return columns;
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
     }
 
     protected abstract ColumnMetaData derivedColumnMetaData(String newColumnName);

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/column/DuplicateColumnsTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/column/DuplicateColumnsTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.column;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.datavec.api.transform.Transform;
@@ -30,12 +31,13 @@ import java.util.Set;
 
 /**
  * Duplicate one or more columns.
- * The duplicated columns are placed immediately after the original columns
+ * The duplicated columns
+ * are placed immediately after the original columns
  *
  * @author Alex Black
  */
 @JsonIgnoreProperties({"columnsToDuplicateSet", "columnIndexesToDuplicateSet", "inputSchema"})
-public class DuplicateColumnsTransform implements Transform {
+public class DuplicateColumnsTransform implements Transform,ColumnOp {
 
     private final List<String> columnsToDuplicate;
     private final List<String> newColumnNames;
@@ -47,7 +49,8 @@ public class DuplicateColumnsTransform implements Transform {
      * @param columnsToDuplicate List of columns to duplicate
      * @param newColumnNames     List of names for the new (duplicate) columns
      */
-    public DuplicateColumnsTransform(@JsonProperty("columnsToDuplicate") List<String> columnsToDuplicate, @JsonProperty("newColumnNames") List<String> newColumnNames) {
+    public DuplicateColumnsTransform(@JsonProperty("columnsToDuplicate") List<String> columnsToDuplicate,
+                                     @JsonProperty("newColumnNames") List<String> newColumnNames) {
         if (columnsToDuplicate == null || newColumnNames == null)
             throw new IllegalArgumentException("Columns/names cannot be null");
         if (columnsToDuplicate.size() != newColumnNames.size())
@@ -150,5 +153,49 @@ public class DuplicateColumnsTransform implements Transform {
         int result = columnsToDuplicate.hashCode();
         result = 31 * result + newColumnNames.hashCode();
         return result;
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return outputColumnNames()[0];
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return newColumnNames.toArray(new String[newColumnNames.size()]);
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return columnsToDuplicate.toArray(new String[columnsToDuplicate.size()]);
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/column/RemoveAllColumnsExceptForTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/column/RemoveAllColumnsExceptForTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.column;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.datavec.api.transform.metadata.ColumnMetaData;
@@ -26,13 +27,16 @@ import org.datavec.api.writable.Writable;
 import java.util.*;
 
 /**
- * Transform that removes all columns except for those that are explicitly specified as ones to keep
- * To specify only the columns to remove, use {@link RemoveColumnsTransform}
+ * Transform that removes all columns except
+ * for those that are explicitly
+ * specified as ones to keep
+ * To specify only the columns
+ * to remove, use {@link RemoveColumnsTransform}
  *
  * @author Alex Black
  */
 @JsonIgnoreProperties({"inputSchema", "columnsToKeepIdx", "indicesToKeep"})
-public class RemoveAllColumnsExceptForTransform extends BaseTransform {
+public class RemoveAllColumnsExceptForTransform extends BaseTransform implements ColumnOp {
 
     private int[] columnsToKeepIdx;
     private String[] columnsToKeep;
@@ -45,7 +49,6 @@ public class RemoveAllColumnsExceptForTransform extends BaseTransform {
     @Override
     public void setInputSchema(Schema schema) {
         super.setInputSchema(schema);
-
         indicesToKeep = new HashSet<>();
 
         int i = 0;
@@ -118,5 +121,49 @@ public class RemoveAllColumnsExceptForTransform extends BaseTransform {
     @Override
     public int hashCode() {
         return Arrays.hashCode(columnsToKeep);
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return outputColumnNames()[0];
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return columnsToKeep;
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return inputSchema.getColumnNames().toArray(new String[inputSchema.numColumns()]);
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/column/RenameColumnsTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/column/RenameColumnsTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.column;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.datavec.api.transform.metadata.ColumnMetaData;
@@ -33,7 +34,7 @@ import java.util.List;
  * @author Alex Black
  */
 @JsonIgnoreProperties({"inputSchema"})
-public class RenameColumnsTransform implements Transform {
+public class RenameColumnsTransform implements Transform,ColumnOp {
 
     private final List<String> oldNames;
     private final List<String> newNames;
@@ -114,5 +115,49 @@ public class RenameColumnsTransform implements Transform {
     @Override
     public String toString() {
         return "RenameColumnsTransform(oldNames=" + oldNames + ",newNames=" + newNames + ")";
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return outputColumnNames()[0];
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return newNames.toArray(new String[newNames.size()]);
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return oldNames.toArray(new String[oldNames.size()]);
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/column/ReorderColumnsTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/column/ReorderColumnsTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.column;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.datavec.api.transform.schema.Schema;
@@ -35,12 +36,11 @@ import java.util.List;
  * @author Alex Black
  */
 @JsonIgnoreProperties({"inputSchema", "outputOrder"})
-public class ReorderColumnsTransform implements Transform {
+public class ReorderColumnsTransform implements Transform,ColumnOp {
 
     private final List<String> newOrder;
     private Schema inputSchema;
     private int[] outputOrder;  //Mapping from in to out. so output[i] = input.get(outputOrder[i])
-
     /**
      * @param newOrder A partial or complete order of the columns in the output
      */
@@ -159,5 +159,49 @@ public class ReorderColumnsTransform implements Transform {
     public String toString(){
         return "ReorderColumnsTransform(newOrder=" + newOrder + ")";
 
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return outputColumnNames()[0];
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return newOrder.toArray(new String[newOrder.size()]);
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return getInputSchema().getColumnNames().toArray(new String[getInputSchema().getColumnNames().size()]);
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnNames()[0];
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/condition/ConditionalCopyValueTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/condition/ConditionalCopyValueTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.condition;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
@@ -32,15 +33,19 @@ import java.util.List;
  * Note that the condition can be any generic condition, including on other column(s), different to the column
  * that will be modified if the condition is satisfied/true.<br>
  * <p>
- * <b>Note</b>: For sequences, this transform use the convention that each step in the sequence is passed to the condition,
- * and replaced (or not) separately (i.e., Condition.condition(List<Writable>) is used on each time step individually)
+ * <b>Note</b>: For sequences, this
+ * transform use the convention that
+ * each step in the sequence is passed
+ * to the condition,
+ * and replaced (or not) separately (i.e., Condition.condition(List<Writable>)
+ * is used on each time step individually)
  *
  * @author Alex Black
  * @see ConditionalReplaceValueTransform to do a conditional replacement with a fixed value (instead of a value from another column)
  */
 @JsonIgnoreProperties({"columnToReplaceIdx", "sourceColumnIdx"})
 @EqualsAndHashCode(exclude = {"columnToReplaceIdx","sourceColumnIdx"})
-public class ConditionalCopyValueTransform implements Transform {
+public class ConditionalCopyValueTransform implements Transform,ColumnOp {
 
     private final String columnToReplace;
     private final String sourceColumn;
@@ -107,5 +112,49 @@ public class ConditionalCopyValueTransform implements Transform {
     @Override
     public String toString() {
         return "ConditionalCopyValueTransform(replaceColumn=\"" + columnToReplace + "\",sourceColumn=" + sourceColumn + ",condition=" + condition + ")";
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return columnToReplace;
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return new String[] {columnToReplace};
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return new String[] {columnName()};
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return sourceColumn;
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/condition/ConditionalReplaceValueTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/condition/ConditionalReplaceValueTransform.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.transform.transform.condition;
 
+import org.datavec.api.transform.ColumnOp;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
@@ -40,7 +41,7 @@ import java.util.List;
  */
 @JsonIgnoreProperties({"columnToReplaceIdx"})
 @EqualsAndHashCode(exclude = {"columnToReplaceIdx"})
-public class ConditionalReplaceValueTransform implements Transform {
+public class ConditionalReplaceValueTransform implements Transform,ColumnOp {
 
     private final String columnToReplace;
     private final Writable newValue;
@@ -103,5 +104,49 @@ public class ConditionalReplaceValueTransform implements Transform {
     @Override
     public String toString() {
         return "ConditionalReplaceValueTransform(replaceColumn=\"" + columnToReplace + "\",newValue=" + newValue + ",condition=" + condition + ")";
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return columnToReplace;
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return columnNames();
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return new String[]{columnToReplace};
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnToReplace;
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/BaseIntegerTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/BaseIntegerTransform.java
@@ -36,7 +36,7 @@ public abstract class BaseIntegerTransform extends BaseColumnTransform {
     public abstract Writable map(Writable writable);
 
     @Override
-    public ColumnMetaData getNewColumnMetaData(String newName, ColumnMetaData oldColumnMeta){
+    public ColumnMetaData getNewColumnMetaData(String newName, ColumnMetaData oldColumnMeta) {
         ColumnMetaData meta = oldColumnMeta.clone();
         meta.setName(newName);
         return meta;

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/normalize/Normalize.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/normalize/Normalize.java
@@ -30,7 +30,6 @@ package org.datavec.api.transform.transform.normalize;
  * @author Alex Black
  */
 public enum Normalize {
-
     MinMax,
     MinMax2,
     Standardize,

--- a/datavec-dataframe/dependency-reduced-pom.xml
+++ b/datavec-dataframe/dependency-reduced-pom.xml
@@ -6,7 +6,7 @@
     <version>0.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>datavec-tablesaw</artifactId>
+  <artifactId>datavec-dataframe</artifactId>
   <name>datavec-dataframe</name>
   <description>High-performance Java Dataframe with integrated columnar storage (fork of tablesaw)</description>
   <developers>

--- a/datavec-dataframe/dependency-reduced-pom.xml
+++ b/datavec-dataframe/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>datavec-parent</artifactId>
     <groupId>org.datavec</groupId>
-    <version>0.7.0</version>
+    <version>0.7.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>datavec-dataframe</artifactId>

--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/api/CategoryColumn.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/api/CategoryColumn.java
@@ -1,5 +1,6 @@
 package org.datavec.dataframe.api;
 
+import org.antlr.stringtemplate.language.Cat;
 import org.datavec.dataframe.columns.AbstractColumn;
 import org.datavec.dataframe.columns.CategoryColumnUtils;
 import org.datavec.dataframe.columns.Column;
@@ -432,6 +433,11 @@ public class CategoryColumn extends AbstractColumn
     return "Category column: " + name();
   }
 
+  /**
+   * Return the raw indexes
+   * that this column contains.
+   * @return
+   */
   public int[] indexes() {
     int[] rowIndexes = new int[size()];
     for (int i = 0; i < size(); i++) {
@@ -440,6 +446,49 @@ public class CategoryColumn extends AbstractColumn
     return rowIndexes;
   }
 
+
+  /**
+   * Return a copy of this column
+   * with the given string appended
+   * @param append the string to append
+   * @return the new columns
+   */
+  public CategoryColumn appendString(CategoryColumn append) {
+    CategoryColumn newColumn = CategoryColumn.create(name() + "[appendSingle]", this.size());
+    for (int r = 0; r < size(); r++) {
+      String value = get(r);
+      newColumn.add(value + append.get(r));
+    }
+
+    return newColumn;
+  }
+
+  /**
+   * Return a copy of this column
+   * with the given string appended
+   * @param append the string to append
+   * @return the new columns
+   */
+  public CategoryColumn appendString(String append) {
+
+    CategoryColumn newColumn = CategoryColumn.create(name() + "[append]", this.size());
+
+    for (int r = 0; r < size(); r++) {
+      String value = get(r);
+      newColumn.add(value + append);
+    }
+
+    return newColumn;
+  }
+
+  /**
+   * Return a copy of this column
+   * with the given regular expressions array
+   * applied to a find and replace
+   * @param regexArray the regex array to replace
+   * @param replacement the replacement array
+   * @return the new column
+   */
   public CategoryColumn replaceAll(String[] regexArray, String replacement) {
 
     CategoryColumn newColumn = CategoryColumn.create(name() + "[repl]", this.size());

--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/api/Table.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/api/Table.java
@@ -264,6 +264,9 @@ public class Table implements Relation, IntIterable {
     return name;
   }
 
+
+
+
   /**
    * Returns a List of the names of all the columns in this table
    */

--- a/datavec-local/src/main/java/org/datavec/local/transforms/DataFrameOps.java
+++ b/datavec-local/src/main/java/org/datavec/local/transforms/DataFrameOps.java
@@ -1,0 +1,35 @@
+package org.datavec.local.transforms;
+
+import org.datavec.api.transform.Transform;
+import org.datavec.api.transform.transform.categorical.CategoricalToIntegerTransform;
+import org.datavec.api.transform.transform.categorical.CategoricalToOneHotTransform;
+import org.datavec.api.transform.transform.condition.ConditionalCopyValueTransform;
+import org.datavec.api.transform.transform.string.AppendStringColumnTransform;
+import org.datavec.dataframe.api.CategoryColumn;
+import org.datavec.dataframe.api.Table;
+
+/**
+ * Created by agibsonccc on 11/11/16.
+ */
+public class DataFrameOps {
+
+    public static void performTransform(Transform transform,Table table) {
+        if(transform instanceof AppendStringColumnTransform) {
+            AppendStringColumnTransform appendStringColumnTransform = (AppendStringColumnTransform) transform;
+            CategoryColumn categoryColumn = (CategoryColumn) table.column(appendStringColumnTransform.getColumnName());
+            table.addColumn(categoryColumn);
+        }
+        else if(transform instanceof CategoricalToIntegerTransform) {
+
+        }
+        else if(transform instanceof CategoricalToOneHotTransform) {
+
+        }
+        else if(transform instanceof ConditionalCopyValueTransform) {
+
+        }
+
+
+    }
+
+}

--- a/datavec-local/src/main/java/org/datavec/local/transforms/TableRecords.java
+++ b/datavec-local/src/main/java/org/datavec/local/transforms/TableRecords.java
@@ -1,5 +1,8 @@
 package org.datavec.local.transforms;
 
+import org.datavec.api.transform.DataAction;
+import org.datavec.api.transform.Transform;
+import org.datavec.api.transform.TransformProcess;
 import org.datavec.api.transform.schema.Schema;
 import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.Writable;
@@ -21,6 +24,20 @@ import java.util.List;
  * @author Adam Gibson
  */
 public class TableRecords {
+
+
+    public static Table transform(Table table,TransformProcess transformProcess) {
+        List<DataAction> dataActions = transformProcess.getActionList();
+        Table ret = table;
+        for(DataAction dataAction : dataActions) {
+          if(dataAction.getTransform() != null) {
+              Transform transform = dataAction.getTransform();
+              
+          }
+        }
+
+        return ret;
+    }
 
     /**
      * Create a matrix from a table where


### PR DESCRIPTION
Adds column names to operations. This is for mapping core api operations to external columnar operations such as spark and datavec local.