### PR TITLE
Work around conflicting versions of Jackson between GeoIP2 and Spark

### DIFF
--- a/datavec-geo/pom.xml
+++ b/datavec-geo/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <geoip2.version>2.8.0</geoip2.version>
+        <geoip2.jackson.version>2.8.2</geoip2.jackson.version>
     </properties>
 
     <dependencies>
@@ -39,6 +40,11 @@
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
             <version>${geoip2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_2.10</artifactId>
+            <version>${geoip2.jackson.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This doesn't actually work very well. We need a better solution...