### PR TITLE
Setup conf on init process

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/LineRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/LineRecordReader.java
@@ -62,6 +62,7 @@ public class LineRecordReader extends BaseRecordReader {
 
     @Override
     public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
+        this.conf = conf;
         initialize(split);
     }
 


### PR DESCRIPTION
While I'm reading the code. it looks like conf param on LineRecordReader are not being initialized in constructor method. Configuration can be set by setConf method, though it seems it could be set on here, too.
Please look on and review it.