### PR TITLE
Remove .transform(null) in BaseImageRecordReader

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -232,19 +232,9 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
     @Override
     public boolean hasNext() {
         if (iter != null) {
-            boolean hasNext = iter.hasNext();
-            if (!hasNext && imageTransform != null) {
-                imageTransform.transform(null);
-            }
-            return hasNext;
+            return iter.hasNext();
         } else if (record != null) {
-            if (hitImage && imageTransform != null) {
-                imageTransform.transform(null);
-            }
             return !hitImage;
-        }
-        if (imageTransform != null) {
-            imageTransform.transform(null);
         }
         throw new IllegalStateException("Indeterminant state: record must not be null, or a file iterator must exist");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In hasNext() there were multiple calls to imageTransform.transform(null). From reviewing the code and our transforms, I could not find any benefits to doing so. Removing this code.

## How was this patch tested?

Ran unit tests and runs on my local.
