### PR TITLE
Make all image transforms thread-safe.

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -28,6 +28,7 @@ import org.bytedeco.javacpp.indexer.Indexer;
 import org.bytedeco.javacpp.indexer.IntIndexer;
 import org.bytedeco.javacpp.indexer.UByteIndexer;
 import org.bytedeco.javacpp.indexer.UShortIndexer;
+import org.bytedeco.javacv.FrameConverter;
 import org.bytedeco.javacv.Java2DFrameConverter;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.data.ImageWritable;
@@ -212,11 +213,10 @@ public class NativeImageLoader extends BaseImageLoader {
     }
 
     public INDArray asMatrix(Mat image) throws IOException {
-        if (imageTransform != null && converter != null) {
-            ImageWritable writable = new ImageWritable(converter.convert(image));
-            writable = imageTransform.transform(writable);
-            image = converter.convert(writable.getFrame());
-        }
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        ImageWritable writable = new ImageWritable(frameConverter.convert(image));
+        writable = imageTransform.transform(writable);
+        image = frameConverter.convert(writable.getFrame());
 
         if (channels > 0 && image.channels() != channels) {
             int code = -1;

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -216,7 +216,10 @@ public class NativeImageLoader extends BaseImageLoader {
     public INDArray asMatrix(Mat image) throws IOException {
         OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
         ImageWritable writable = new ImageWritable(frameConverter.convert(image));
-        writable = imageTransform.transform(writable);
+
+        if (imageTransform !=null)
+            writable = imageTransform.transform(writable);
+
         image = frameConverter.convert(writable.getFrame());
 
         if (channels > 0 && image.channels() != channels) {

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BaseImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BaseImageTransform.java
@@ -15,6 +15,7 @@
  */
 package org.datavec.image.transform;
 
+import java.util.Map;
 import java.util.Random;
 
 import org.bytedeco.javacv.FrameConverter;
@@ -30,7 +31,7 @@ import org.datavec.image.data.ImageWritable;
 public abstract class BaseImageTransform<F> implements ImageTransform {
 
     protected Random random;
-//    protected FrameConverter<F> converter; // TODO: this isn't thread-safe, maybe class ref instead?
+    Map<Long, FrameConverter<F>> safeConverter;
 
     protected BaseImageTransform(Random random) {
         this.random = random;
@@ -40,5 +41,7 @@ public abstract class BaseImageTransform<F> implements ImageTransform {
     public ImageWritable transform(ImageWritable image) {
         return transform(image, random);
     }
+
+    abstract FrameConverter<F> getSafeConverter(long threadId);
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BaseImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BaseImageTransform.java
@@ -30,7 +30,7 @@ import org.datavec.image.data.ImageWritable;
 public abstract class BaseImageTransform<F> implements ImageTransform {
 
     protected Random random;
-    protected FrameConverter<F> converter;
+//    protected FrameConverter<F> converter; // TODO: this isn't thread-safe, maybe class ref instead?
 
     protected BaseImageTransform(Random random) {
         this.random = random;

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
@@ -49,7 +49,6 @@ public class ColorConversionTransform extends BaseImageTransform {
     public ColorConversionTransform(Random random, int conversionCode) {
         super(random);
         this.conversionCode = conversionCode;
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     /**
@@ -65,7 +64,8 @@ public class ColorConversionTransform extends BaseImageTransform {
         if (image == null) {
             return null;
         }
-        Mat mat = (Mat) converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        Mat mat = frameConverter.convert(image.getFrame());
 
         Mat result = new Mat();
 
@@ -75,7 +75,7 @@ public class ColorConversionTransform extends BaseImageTransform {
             throw new RuntimeException(e);
         }
 
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
@@ -15,8 +15,11 @@
  */
 package org.datavec.image.transform;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
+import org.bytedeco.javacv.FrameConverter;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.data.ImageWritable;
 
@@ -49,6 +52,7 @@ public class ColorConversionTransform extends BaseImageTransform {
     public ColorConversionTransform(Random random, int conversionCode) {
         super(random);
         this.conversionCode = conversionCode;
+        this.safeConverter = new HashMap<>();
     }
 
     /**
@@ -64,7 +68,7 @@ public class ColorConversionTransform extends BaseImageTransform {
         if (image == null) {
             return null;
         }
-        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        FrameConverter<Mat> frameConverter = getSafeConverter(Thread.currentThread().getId());
         Mat mat = frameConverter.convert(image.getFrame());
 
         Mat result = new Mat();
@@ -76,6 +80,16 @@ public class ColorConversionTransform extends BaseImageTransform {
         }
 
         return new ImageWritable(frameConverter.convert(result));
+    }
+
+    protected FrameConverter<Mat> getSafeConverter(long threadId) {
+        if(safeConverter.containsKey(threadId))
+            return (FrameConverter<Mat>) safeConverter.get(Thread.currentThread().getId());
+        else {
+            FrameConverter<Mat> converter = new OpenCVFrameConverter.ToMat();
+            safeConverter.put(threadId, converter);
+            return converter;
+        }
     }
 
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/CropImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/CropImageTransform.java
@@ -60,8 +60,6 @@ public class CropImageTransform extends BaseImageTransform<Mat> {
         this.cropLeft = cropLeft;
         this.cropBottom = cropBottom;
         this.cropRight = cropRight;
-
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     /**
@@ -77,7 +75,9 @@ public class CropImageTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
-        Mat mat = converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+
+        Mat mat = frameConverter.convert(image.getFrame());
         int top = random != null ? random.nextInt(cropTop + 1) : cropTop;
         int left = random != null ? random.nextInt(cropLeft + 1) : cropLeft;
         int bottom = random != null ? random.nextInt(cropBottom + 1) : cropBottom;
@@ -90,7 +90,7 @@ public class CropImageTransform extends BaseImageTransform<Mat> {
         Mat result = mat.apply(new Rect(x, y, w, h));
 
 
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
@@ -15,9 +15,11 @@
  */
 package org.datavec.image.transform;
 
+import org.bytedeco.javacv.FrameConverter;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.data.ImageWritable;
 
+import java.util.HashMap;
 import java.util.Random;
 
 import static org.bytedeco.javacpp.opencv_core.Mat;
@@ -53,6 +55,7 @@ public class EqualizeHistTransform extends BaseImageTransform {
     public EqualizeHistTransform(Random random, int conversionCode) {
         super(random);
         this.conversionCode = conversionCode;
+        this.safeConverter = new HashMap<>();
     }
 
     /**
@@ -69,7 +72,7 @@ public class EqualizeHistTransform extends BaseImageTransform {
         if (image == null) {
             return null;
         }
-        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        FrameConverter<Mat> frameConverter = getSafeConverter(Thread.currentThread().getId());
         Mat mat = frameConverter.convert(image.getFrame());
         Mat result = new Mat();
         try {
@@ -87,6 +90,15 @@ public class EqualizeHistTransform extends BaseImageTransform {
         return new ImageWritable(frameConverter.convert(result));
     }
 
+    protected FrameConverter<Mat> getSafeConverter(long threadId) {
+        if(safeConverter.containsKey(threadId))
+            return (FrameConverter<Mat>) safeConverter.get(Thread.currentThread().getId());
+        else {
+            FrameConverter<Mat> converter = new OpenCVFrameConverter.ToMat();
+            safeConverter.put(threadId, converter);
+            return converter;
+        }
+    }
 
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
@@ -53,7 +53,6 @@ public class EqualizeHistTransform extends BaseImageTransform {
     public EqualizeHistTransform(Random random, int conversionCode) {
         super(random);
         this.conversionCode = conversionCode;
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     /**
@@ -70,7 +69,8 @@ public class EqualizeHistTransform extends BaseImageTransform {
         if (image == null) {
             return null;
         }
-        Mat mat = (Mat) converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        Mat mat = frameConverter.convert(image.getFrame());
         Mat result = new Mat();
         try {
             if (mat.channels() == 1) {
@@ -84,7 +84,7 @@ public class EqualizeHistTransform extends BaseImageTransform {
             throw new RuntimeException(e);
         }
 
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/FlipImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/FlipImageTransform.java
@@ -58,7 +58,6 @@ public class FlipImageTransform extends BaseImageTransform<Mat> {
      */
     public FlipImageTransform(Random random) {
         super(random);
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     @Override
@@ -66,7 +65,8 @@ public class FlipImageTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
-        Mat mat = converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        Mat mat = frameConverter.convert(image.getFrame());
 
         int mode = random != null ? random.nextInt(4) - 2 : flipMode;
 
@@ -78,7 +78,7 @@ public class FlipImageTransform extends BaseImageTransform<Mat> {
             flip(mat, result, mode);
         }
 
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 }
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/MultiImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/MultiImageTransform.java
@@ -1,5 +1,6 @@
 package org.datavec.image.transform;
 
+import org.bytedeco.javacv.FrameConverter;
 import org.datavec.image.data.ImageWritable;
 
 import java.util.Random;
@@ -31,5 +32,9 @@ public class MultiImageTransform extends BaseImageTransform<Mat> {
     @Override
     public ImageWritable transform(ImageWritable image) {
         return transform.transform(image);
+    }
+
+    protected FrameConverter<Mat> getSafeConverter(long threadId) {
+        throw new UnsupportedOperationException("Frame converters are used at individual transform levels");
     }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
@@ -18,6 +18,7 @@ package org.datavec.image.transform;
 import java.util.*;
 
 import lombok.NonNull;
+import org.bytedeco.javacv.FrameConverter;
 import org.datavec.api.berkeley.Pair;
 import org.datavec.image.data.ImageWritable;
 import org.nd4j.linalg.factory.Nd4j;
@@ -165,5 +166,9 @@ public class PipelineImageTransform extends BaseImageTransform<Mat> {
             else
                 return new PipelineImageTransform(imageTransforms);
         }
+    }
+
+    protected FrameConverter<Mat> getSafeConverter(long threadId) {
+        throw new UnsupportedOperationException("Frame converters are used at individual transform levels");
     }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/RandomCropTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/RandomCropTransform.java
@@ -48,8 +48,6 @@ public class RandomCropTransform extends BaseImageTransform<Mat> {
         this.outputWidth = width;
         this.rng = Nd4j.getRandom();
         rng.setSeed(seed);
-
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     /**
@@ -64,6 +62,8 @@ public class RandomCropTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+
         // ensure that transform is valid
         if (image.getFrame().imageHeight < outputHeight || image.getFrame().imageWidth < outputWidth)
             throw new UnsupportedOperationException(
@@ -75,7 +75,7 @@ public class RandomCropTransform extends BaseImageTransform<Mat> {
         int cropTop = image.getFrame().imageHeight - outputHeight;
         int cropLeft = image.getFrame().imageWidth - outputWidth;
 
-        Mat mat = converter.convert(image.getFrame());
+        Mat mat = frameConverter.convert(image.getFrame());
         int top = rng.nextInt(cropTop + 1);
         int left = rng.nextInt(cropLeft + 1);
 
@@ -83,8 +83,7 @@ public class RandomCropTransform extends BaseImageTransform<Mat> {
         int x = Math.min(left, mat.cols() - 1);
         Mat result = mat.apply(new Rect(x, y, outputWidth, outputHeight));
 
-
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ResizeImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ResizeImageTransform.java
@@ -54,8 +54,6 @@ public class ResizeImageTransform extends BaseImageTransform<opencv_core.Mat> {
 
         this.newWidth = newWidth;
         this.newHeight = newHeight;
-
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     /**
@@ -71,10 +69,11 @@ public class ResizeImageTransform extends BaseImageTransform<opencv_core.Mat> {
         if (image == null) {
             return null;
         }
-        opencv_core.Mat mat = converter.convert(image.getFrame());
+        OpenCVFrameConverter<opencv_core.Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        opencv_core.Mat mat = frameConverter.convert(image.getFrame());
         opencv_core.Mat result = new opencv_core.Mat();
         resize(mat, result, new opencv_core.Size(newWidth, newHeight));
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/RotateImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/RotateImageTransform.java
@@ -71,8 +71,6 @@ public class RotateImageTransform extends BaseImageTransform<Mat> {
         this.centery = centery;
         this.angle = angle;
         this.scale = scale;
-
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     @Override
@@ -80,7 +78,9 @@ public class RotateImageTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
-        Mat mat = converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+
+        Mat mat = frameConverter.convert(image.getFrame());
         float cy = mat.rows() / 2 + centery * (random != null ? 2 * random.nextFloat() - 1 : 1);
         float cx = mat.cols() / 2 + centerx * (random != null ? 2 * random.nextFloat() - 1 : 1);
         float a = angle * (random != null ? 2 * random.nextFloat() - 1 : 1);
@@ -89,7 +89,7 @@ public class RotateImageTransform extends BaseImageTransform<Mat> {
         Mat result = new Mat();
         Mat M = getRotationMatrix2D(new Point2f(cx, cy), angle, scale);
         warpAffine(mat, result, M, mat.size(), interMode, borderMode, borderValue);
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ScaleImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ScaleImageTransform.java
@@ -58,8 +58,6 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
         super(random);
         this.dx = dx;
         this.dy = dy;
-
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     @Override
@@ -67,13 +65,15 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
-        Mat mat = converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+
+        Mat mat = frameConverter.convert(image.getFrame());
         int h = Math.round(mat.rows() + dy * (random != null ? 2 * random.nextFloat() - 1 : 1));
         int w = Math.round(mat.cols() + dx * (random != null ? 2 * random.nextFloat() - 1 : 1));
 
         Mat result = new Mat();
         resize(mat, result, new Size(w, h));
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ScaleImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ScaleImageTransform.java
@@ -15,8 +15,10 @@
  */
 package org.datavec.image.transform;
 
+import java.util.HashMap;
 import java.util.Random;
 
+import org.bytedeco.javacv.FrameConverter;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.data.ImageWritable;
 
@@ -58,6 +60,7 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
         super(random);
         this.dx = dx;
         this.dy = dy;
+        this.safeConverter = new HashMap<>();
     }
 
     @Override
@@ -65,7 +68,7 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
-        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+        FrameConverter<Mat> frameConverter = getSafeConverter(Thread.currentThread().getId());
 
         Mat mat = frameConverter.convert(image.getFrame());
         int h = Math.round(mat.rows() + dy * (random != null ? 2 * random.nextFloat() - 1 : 1));
@@ -74,6 +77,16 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
         Mat result = new Mat();
         resize(mat, result, new Size(w, h));
         return new ImageWritable(frameConverter.convert(result));
+    }
+
+    protected FrameConverter<Mat> getSafeConverter(long threadId) {
+        if(safeConverter.containsKey(threadId))
+            return (FrameConverter<Mat>) safeConverter.get(Thread.currentThread().getId());
+        else {
+            FrameConverter<Mat> converter = new OpenCVFrameConverter.ToMat();
+            safeConverter.put(threadId, converter);
+            return converter;
+        }
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
@@ -15,11 +15,15 @@
  */
 package org.datavec.image.transform;
 
+import java.util.HashMap;
 import java.util.Random;
 import javax.swing.JFrame;
 
+import org.bytedeco.javacpp.opencv_core;
 import org.bytedeco.javacv.CanvasFrame;
 import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.FrameConverter;
+import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.data.ImageWritable;
 
 /**
@@ -87,6 +91,10 @@ public class ShowImageTransform extends BaseImageTransform {
             }
         }
         return image;
+    }
+
+    protected FrameConverter<opencv_core.Mat> getSafeConverter(long threadId) {
+        throw new UnsupportedOperationException("Converters are not needed for ShowImageTransform.");
     }
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
@@ -70,10 +70,8 @@ public class ShowImageTransform extends BaseImageTransform {
 
     @Override
     public ImageWritable transform(ImageWritable image, Random random) {
-        if (image == null) {
-            canvas.dispose();
-            return null;
-        }
+        canvas.dispose(); // clean-up
+
         if (!canvas.isVisible()) {
             return image;
         }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/WarpImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/WarpImageTransform.java
@@ -86,8 +86,6 @@ public class WarpImageTransform extends BaseImageTransform<Mat> {
         deltas[5] = dy3;
         deltas[6] = dx4;
         deltas[7] = dy4;
-
-        converter = new OpenCVFrameConverter.ToMat();
     }
 
     /**
@@ -103,7 +101,9 @@ public class WarpImageTransform extends BaseImageTransform<Mat> {
         if (image == null) {
             return null;
         }
-        Mat mat = converter.convert(image.getFrame());
+        OpenCVFrameConverter<Mat> frameConverter = new OpenCVFrameConverter.ToMat();
+
+        Mat mat = frameConverter.convert(image.getFrame());
         Point2f src = new Point2f(4);
         Point2f dst = new Point2f(4);
         src.put(0, 0, mat.cols(), 0, mat.cols(), mat.rows(), 0, mat.rows());
@@ -115,7 +115,7 @@ public class WarpImageTransform extends BaseImageTransform<Mat> {
         Mat M = getPerspectiveTransform(src, dst);
         warpPerspective(mat, result, M, mat.size(), interMode, borderMode, borderValue);
 
-        return new ImageWritable(converter.convert(result));
+        return new ImageWritable(frameConverter.convert(result));
     }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because of incoming changes with https://github.com/deeplearning4j/deeplearning4j/pull/3258 all transforms being used by RecordReaderDataSetIterator will need to be thread-safe.

One concern here is will this create a lot of memory pointers? Is that a problem? Are we going to see OOMs with large numbers of images?

## How was this patch tested?

Ran tests and also implemented in long-running training process.