### PR TITLE
Dh 3198 cifar10

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/CifarLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/CifarLoader.java
@@ -317,8 +317,8 @@ public class CifarLoader extends NativeImageLoader implements Serializable {
         ByteBuffer imageData = image.createBuffer();
 
         for (int i = 0; i < HEIGHT * WIDTH; i++) {
-            imageData.put(3 * i, byteFeature[i + 1 + 2 * height * width]); // blue
-            imageData.put(3 * i + 1, byteFeature[i + 1 + height * width]); // green
+            imageData.put(3 * i, byteFeature[i + 1 + 2 * HEIGHT * WIDTH]); // blue
+            imageData.put(3 * i + 1, byteFeature[i + 1 + HEIGHT * WIDTH]); // green
             imageData.put(3 * i + 2, byteFeature[i + 1]); // red
         }
         //        if (useSpecialPreProcessCifar) {

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/LoaderTests.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/LoaderTests.java
@@ -148,6 +148,26 @@ public class LoaderTests {
         assertEquals(numExamples, data.getLabels().size(0));
     }
 
+    @Test
+    public void testCifarLoaderWithBiggerImage() {
+        boolean train = true;
+        boolean preProcessCifar = false;
+        int row = 128;
+        int col = 128;
+        int channels = 3;
+        int numExamples = 10;
+
+        CifarLoader loader = new CifarLoader(row, col, channels, train, preProcessCifar);
+        DataSet data = loader.next(numExamples);
+        int shape[] = data.getFeatures().shape();
+        assertEquals(shape.length, 4);
+        assertEquals(shape[0], numExamples);
+        assertEquals(shape[1], channels);
+        assertEquals(shape[2], row);
+        assertEquals(shape[2], col);
+
+    }
+
 
     @Ignore // Use when confirming data is getting stored
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

in current master, when users try to set bigger size(say, 3x128x128) than it's original size(3x32x32), it has errors like this(https://github.com/deeplearning4j/deeplearning4j/issues/3198)

the cause of this situation was trying to use bigger size(128) to load the original image(3x32x32).

## How was this patch tested?

unit test codes are included in this PR.



