### PR TITLE
Only rebuild needed modules between different scala/spark version builds

### DIFF
--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,12 +1,22 @@
 #! /bin/bash
+BASEDIR=$(dirname $(readlink -f "$0"))
+
+function whatchanged() {
+    cd $BASEDIR
+    for i in $(git status -s --porcelain -- $(find ./ -mindepth 2 -name pom.xml)|awk '{print $2}'); do
+	echo $(dirname $i)
+	cd $BASEDIR
+    done
+}
+
 set -eu
 ./change-scala-versions.sh 2.11 # should be idempotent, this is the default
 ./change-spark-versions.sh 1
 mvn "$@"
 ./change-spark-versions.sh 2
-mvn -Dspark.major.version=2 "$@"
+mvn -Dspark.major.version=2 -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
 ./change-scala-versions.sh 2.10
 ./change-spark-versions.sh 1
-mvn "$@"
+mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
 ./change-scala-versions.sh 2.11 # back to the default
 ./change-spark-versions.sh 1


### PR DESCRIPTION
Reduces build time of `./buildmultiplescalaversions.sh clean install -DskipTests=true`
 from 149s to 84s
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/2873