### PR TITLE
Add AndroidNativeImageLoader and Java2DNativeImageLoader

### DIFF
--- a/datavec-data/datavec-data-image/pom.xml
+++ b/datavec-data/datavec-data-image/pom.xml
@@ -59,28 +59,34 @@
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
             <version>3.1.1</version>
-           
-
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-tiff</artifactId>
             <version>3.1.1</version>
-           
-
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-psd</artifactId>
             <version>3.1.1</version>
-           
-
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-bmp</artifactId>
             <version>3.1.1</version>
-           
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+            <version>4.1.1.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -107,5 +113,19 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>com.google.android:android</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/AndroidNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/AndroidNativeImageLoader.java
@@ -1,0 +1,77 @@
+/*-
+ *  * Copyright 2017 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+package org.datavec.image.loader;
+
+import android.graphics.Bitmap;
+import java.io.IOException;
+import org.bytedeco.javacv.AndroidFrameConverter;
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.datavec.image.transform.ImageTransform;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * Segregates functionality specific to Android that is not available on Java SE.
+ *
+ * @author saudet
+ */
+public class AndroidNativeImageLoader extends NativeImageLoader {
+
+    AndroidFrameConverter converter2 = new AndroidFrameConverter();
+
+    public AndroidNativeImageLoader() {}
+
+    public AndroidNativeImageLoader(int height, int width) {
+        super(height, width);
+    }
+
+    public AndroidNativeImageLoader(int height, int width, int channels) {
+        super(height, width, channels);
+    }
+
+    public AndroidNativeImageLoader(int height, int width, int channels, boolean centerCropIfNeeded) {
+        super(height, width, channels, centerCropIfNeeded);
+    }
+
+    public AndroidNativeImageLoader(int height, int width, int channels, ImageTransform imageTransform) {
+        super(height, width, channels, imageTransform);
+    }
+
+    protected AndroidNativeImageLoader(NativeImageLoader other) {
+        super(other);
+    }
+
+    public INDArray asRowVector(Bitmap image) throws IOException {
+        return asMatrix(image).ravel();
+    }
+
+    public INDArray asMatrix(Bitmap image) throws IOException {
+        if (converter == null) {
+            converter = new OpenCVFrameConverter.ToMat();
+        }
+        return asMatrix(converter.convert(converter2.convert(image)));
+    }
+
+    @Override
+    public INDArray asRowVector(Object image) throws IOException {
+        return image instanceof Bitmap ? asRowVector((Bitmap)image) : null;
+    }
+
+    @Override
+    public INDArray asMatrix(Object image) throws IOException {
+        return image instanceof Bitmap ? asMatrix((Bitmap)image) : null;
+    }
+
+}

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/Java2DNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/Java2DNativeImageLoader.java
@@ -1,0 +1,77 @@
+/*-
+ *  * Copyright 2017 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+package org.datavec.image.loader;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import org.bytedeco.javacv.Java2DFrameConverter;
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.datavec.image.transform.ImageTransform;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * Segregates functionality specific to Java 2D that is not available on Android.
+ *
+ * @author saudet
+ */
+public class Java2DNativeImageLoader extends NativeImageLoader {
+
+    Java2DFrameConverter converter2 = new Java2DFrameConverter();
+
+    public Java2DNativeImageLoader() {}
+
+    public Java2DNativeImageLoader(int height, int width) {
+        super(height, width);
+    }
+
+    public Java2DNativeImageLoader(int height, int width, int channels) {
+        super(height, width, channels);
+    }
+
+    public Java2DNativeImageLoader(int height, int width, int channels, boolean centerCropIfNeeded) {
+        super(height, width, channels, centerCropIfNeeded);
+    }
+
+    public Java2DNativeImageLoader(int height, int width, int channels, ImageTransform imageTransform) {
+        super(height, width, channels, imageTransform);
+    }
+
+    protected Java2DNativeImageLoader(NativeImageLoader other) {
+        super(other);
+    }
+
+    public INDArray asRowVector(BufferedImage image) throws IOException {
+        return asMatrix(image).ravel();
+    }
+
+    public INDArray asMatrix(BufferedImage image) throws IOException {
+        if (converter == null) {
+            converter = new OpenCVFrameConverter.ToMat();
+        }
+        return asMatrix(converter.convert(converter2.convert(image)));
+    }
+
+    @Override
+    public INDArray asRowVector(Object image) throws IOException {
+        return image instanceof BufferedImage ? asRowVector((BufferedImage)image) : null;
+    }
+
+    @Override
+    public INDArray asMatrix(Object image) throws IOException {
+        return image instanceof BufferedImage ? asMatrix((BufferedImage)image) : null;
+    }
+
+}


### PR DESCRIPTION
Fixes deeplearning4j/deeplearning4j#3245

## What changes were proposed in this pull request?

Segregates functionality for BufferedImage in a new Java2DNativeImageLoader class and also add similar functionality for loading Bitmap in the AndroidNativeImageLoader class.

## How was this patch tested?

Unit tests pass with Maven for Java SE and manually tested on Android.