### PR TITLE
Added largest blob crop transform

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/LargestBlobCropTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/LargestBlobCropTransform.java
@@ -1,0 +1,106 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+package org.datavec.image.transform;
+
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.datavec.image.data.ImageWritable;
+import org.datavec.image.transform.BaseImageTransform;
+import org.jfree.util.Log;
+import org.nd4j.linalg.factory.Nd4j;
+import java.util.Random;
+import static org.bytedeco.javacpp.opencv_core.*;
+import static org.bytedeco.javacpp.opencv_imgproc.*;
+
+public class LargestBlobCropTransform extends BaseImageTransform<Mat> {
+
+    protected org.nd4j.linalg.api.rng.Random rng;
+
+    protected int mode,method,blurWidth,blurHeight,upperThresh,lowerThresh,cannyOrThresh;
+
+    public LargestBlobCropTransform() {
+        this(null);
+    }
+
+    public LargestBlobCropTransform(Random random) {
+        this(random, CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE, 3, 3, 100, 200 , 0);
+    }
+
+    public LargestBlobCropTransform(Random random, int mode, int method, int blurWidth, int blurHeight, int UpperThresh, int LowerThresh, int CannyOrThresh){
+        super(random);
+        this.rng = Nd4j.getRandom();
+        this.mode = mode;
+        this.method = method;
+        this.blurWidth = blurWidth;
+        this.blurHeight = blurHeight;
+        this.lowerThresh = LowerThresh;
+        this.upperThresh = UpperThresh;
+        this.cannyOrThresh = CannyOrThresh;
+
+        converter = new OpenCVFrameConverter.ToMat();
+    }
+
+    /**
+     * Takes an image and returns a cropped image based on it's largest blob.
+     *
+     * @param image  to transform, null == end of stream
+     * @param random object to use (or null for deterministic)
+     * @return transformed image
+     */
+    @Override
+    public ImageWritable transform(ImageWritable image, Random random) {
+        if (image == null) {;
+            return null;
+        }
+
+        //Convert image to gray and blur
+        Mat original = converter.convert(image.getFrame());
+        Mat grayed = new Mat();
+        cvtColor( original, grayed, CV_BGR2GRAY );
+        if (blurWidth > 0 && blurHeight > 0)
+            blur( grayed, grayed, new Size(blurWidth,blurHeight));
+
+        //Get edges from Canny edge detector
+        Mat edgeOut = new Mat();
+        if (cannyOrThresh == 0)
+            Canny( grayed, edgeOut, lowerThresh, upperThresh );
+        else
+            threshold(grayed, edgeOut,lowerThresh,upperThresh, 0);
+
+        double largestArea = 0;
+        Rect boundingRect = new Rect();
+        MatVector contours = new MatVector();
+        Mat hierarchy = new Mat();
+
+        findContours(edgeOut, contours, hierarchy, this.mode, this.method);
+
+        for( int i = 0; i< contours.size(); i++ )
+        {
+            //  Find the area of contour
+            double a=contourArea( contours.get(i),false);
+
+            if(a>largestArea){
+                // Find the bounding rectangle for biggest contour
+                boundingRect=boundingRect(contours.get(i));
+            }
+        }
+
+        //Apply crop and return result
+        Mat result = original.apply(boundingRect);
+
+        return new ImageWritable(converter.convert(result));
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Made a transform function for cropping the largest blob from an image.

## How was this patch tested?

I ran it with MNIST and Cifar-10 datasets and used ShowImageTransform to validify the crops. Also used drawContours() from the OpenCV API to confirm the right blob was being cropped.
