### PR TITLE
Add NativeAudioRecordReader to read audio data (AAC, MP3, WAV, etc) with FFmpeg

### DIFF
--- a/datavec-data/datavec-data-audio/pom.xml
+++ b/datavec-data/datavec-data-audio/pom.xml
@@ -38,5 +38,26 @@
             <artifactId>datavec-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <version>${javacpp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacv</artifactId>
+            <version>${javacv.version}</version>
+        </dependency>
+
+<!-- Do not depend on FFmpeg by default due to licensing concerns. -->
+<!--
+        <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>ffmpeg-platform</artifactId>
+            <version>${ffmpeg.version}-${javacpp-presets.version}</version>
+        </dependency>
+-->
+
     </dependencies>
 </project>

--- a/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/recordreader/BaseAudioRecordReader.java
+++ b/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/recordreader/BaseAudioRecordReader.java
@@ -1,0 +1,211 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.audio.recordreader;
+
+import org.apache.commons.io.FileUtils;
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.records.Record;
+import org.datavec.api.records.metadata.RecordMetaData;
+import org.datavec.api.writable.DoubleWritable;
+import org.datavec.api.records.reader.BaseRecordReader;
+import org.datavec.api.split.BaseInputSplit;
+import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.InputStreamInputSplit;
+import org.datavec.api.writable.Writable;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ * Base audio file loader
+ * @author Adam Gibson
+ */
+public abstract class BaseAudioRecordReader extends BaseRecordReader {
+    private Iterator<File> iter;
+    private List<Writable> record;
+    private boolean hitImage = false;
+    private boolean appendLabel = false;
+    private List<String> labels = new ArrayList<>();
+    private Configuration conf;
+    protected InputSplit inputSplit;
+
+    public BaseAudioRecordReader() {}
+
+    public BaseAudioRecordReader(boolean appendLabel, List<String> labels) {
+        this.appendLabel = appendLabel;
+        this.labels = labels;
+    }
+
+    public BaseAudioRecordReader(List<String> labels) {
+        this.labels = labels;
+    }
+
+    public BaseAudioRecordReader(boolean appendLabel) {
+        this.appendLabel = appendLabel;
+    }
+
+    protected abstract List<Writable> loadData(File file, InputStream inputStream) throws IOException;
+
+    @Override
+    public void initialize(InputSplit split) throws IOException, InterruptedException {
+        inputSplit = split;
+        if (split instanceof BaseInputSplit) {
+            URI[] locations = split.locations();
+            if (locations != null && locations.length >= 1) {
+                if (locations.length > 1) {
+                    List<File> allFiles = new ArrayList<>();
+                    for (URI location : locations) {
+                        File iter = new File(location);
+                        if (iter.isDirectory()) {
+                            Iterator<File> allFiles2 = FileUtils.iterateFiles(iter, null, true);
+                            while (allFiles2.hasNext())
+                                allFiles.add(allFiles2.next());
+                        }
+
+                        else
+                            allFiles.add(iter);
+                    }
+
+                    iter = allFiles.iterator();
+                } else {
+                    File curr = new File(locations[0]);
+                    if (curr.isDirectory())
+                        iter = FileUtils.iterateFiles(curr, null, true);
+                    else
+                        iter = Collections.singletonList(curr).iterator();
+                }
+            }
+        }
+
+
+        else if (split instanceof InputStreamInputSplit) {
+            record = new ArrayList<>();
+            InputStreamInputSplit split2 = (InputStreamInputSplit) split;
+            InputStream is = split2.getIs();
+            URI[] locations = split2.locations();
+            if (appendLabel) {
+                Path path = Paths.get(locations[0]);
+                String parent = path.getParent().toString();
+                record.add(new DoubleWritable(labels.indexOf(parent)));
+            }
+
+            is.close();
+        }
+
+    }
+
+    @Override
+    public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
+        this.conf = conf;
+        this.appendLabel = conf.getBoolean(APPEND_LABEL, false);
+        this.labels = new ArrayList<>(conf.getStringCollection(LABELS));
+        initialize(split);
+    }
+
+    @Override
+    public List<Writable> next() {
+        if (iter != null) {
+            File next = iter.next();
+            invokeListeners(next);
+            try {
+                return loadData(next, null);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else if (record != null) {
+            hitImage = true;
+            return record;
+        }
+
+        throw new IllegalStateException("Indeterminant state: record must not be null, or a file iterator must exist");
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (iter != null) {
+            return iter.hasNext();
+        } else if (record != null) {
+            return !hitImage;
+        }
+        throw new IllegalStateException("Indeterminant state: record must not be null, or a file iterator must exist");
+    }
+
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public Configuration getConf() {
+        return conf;
+    }
+
+    @Override
+    public List<String> getLabels() {
+        return null;
+    }
+
+
+    @Override
+    public void reset() {
+        if (inputSplit == null)
+            throw new UnsupportedOperationException("Cannot reset without first initializing");
+        try {
+            initialize(inputSplit);
+        } catch (Exception e) {
+            throw new RuntimeException("Error during LineRecordReader reset", e);
+        }
+
+    }
+
+    @Override
+    public List<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException {
+        invokeListeners(uri);
+        try {
+            return loadData(null, dataInputStream);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Record nextRecord() {
+        return new org.datavec.api.records.impl.Record(next(), null);
+    }
+
+    @Override
+    public Record loadFromMetaData(RecordMetaData recordMetaData) throws IOException {
+        throw new UnsupportedOperationException("Loading from metadata not yet implemented");
+    }
+
+    @Override
+    public List<Record> loadFromMetaData(List<RecordMetaData> recordMetaDatas) throws IOException {
+        throw new UnsupportedOperationException("Loading from metadata not yet implemented");
+    }
+}

--- a/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/recordreader/NativeAudioRecordReader.java
+++ b/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/recordreader/NativeAudioRecordReader.java
@@ -1,0 +1,72 @@
+/*-
+ *  * Copyright 2017 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.audio.recordreader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.FloatBuffer;
+import java.util.*;
+
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.datavec.api.writable.FloatWritable;
+import org.datavec.api.writable.Writable;
+
+import static org.bytedeco.javacpp.avutil.*;
+
+/**
+ * Native audio file loader using FFmpeg.
+ *
+ * @author saudet
+ */
+public class NativeAudioRecordReader extends BaseAudioRecordReader {
+
+    public NativeAudioRecordReader() {}
+
+    public NativeAudioRecordReader(boolean appendLabel, List<String> labels) {
+        super(appendLabel, labels);
+    }
+
+    public NativeAudioRecordReader(List<String> labels) {
+        super(labels);
+    }
+
+    public NativeAudioRecordReader(boolean appendLabel) {
+        super(appendLabel);
+    }
+
+    protected List<Writable> loadData(File file, InputStream inputStream) throws IOException {
+        List<Writable> ret = new ArrayList<>();
+        try (FFmpegFrameGrabber grabber = inputStream != null
+                ? new FFmpegFrameGrabber(inputStream)
+                : new FFmpegFrameGrabber(file.getAbsolutePath())) {
+            grabber.setSampleFormat(AV_SAMPLE_FMT_FLT);
+            grabber.start();
+            Frame frame;
+            while ((frame = grabber.grab()) != null) {
+                while (frame.samples != null && frame.samples[0].hasRemaining()) {
+                    for (int i = 0; i < frame.samples.length; i++) {
+                        ret.add(new FloatWritable(((FloatBuffer)frame.samples[i]).get()));
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+}

--- a/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/recordreader/WavFileRecordReader.java
+++ b/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/recordreader/WavFileRecordReader.java
@@ -16,190 +16,38 @@
 
 package org.datavec.audio.recordreader;
 
-import org.apache.commons.io.FileUtils;
-import org.datavec.api.conf.Configuration;
-import org.datavec.api.records.Record;
-import org.datavec.api.records.metadata.RecordMetaData;
-import org.datavec.api.writable.DoubleWritable;
-import org.datavec.api.records.reader.BaseRecordReader;
-import org.datavec.api.split.FileSplit;
-import org.datavec.api.split.InputSplit;
-import org.datavec.api.split.InputStreamInputSplit;
 import org.datavec.api.util.RecordUtils;
 import org.datavec.api.writable.Writable;
 import org.datavec.audio.Wave;
 
-import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
 /**
  * Wav file loader
  * @author Adam Gibson
  */
-public class WavFileRecordReader extends BaseRecordReader {
-    private Iterator<File> iter;
-    private List<Writable> record;
-    private boolean hitImage = false;
-    private boolean appendLabel = false;
-    private List<String> labels = new ArrayList<>();
-    private Configuration conf;
-    protected InputSplit inputSplit;
+public class WavFileRecordReader extends BaseAudioRecordReader {
 
     public WavFileRecordReader() {}
 
     public WavFileRecordReader(boolean appendLabel, List<String> labels) {
-        this.appendLabel = appendLabel;
-        this.labels = labels;
+        super(appendLabel, labels);
     }
 
     public WavFileRecordReader(List<String> labels) {
-        this.labels = labels;
+        super(labels);
     }
 
     public WavFileRecordReader(boolean appendLabel) {
-        this.appendLabel = appendLabel;
+        super(appendLabel);
     }
 
-    @Override
-    public void initialize(InputSplit split) throws IOException, InterruptedException {
-        inputSplit = split;
-        if (split instanceof FileSplit) {
-            URI[] locations = split.locations();
-            if (locations != null && locations.length >= 1) {
-                if (locations.length > 1) {
-                    List<File> allFiles = new ArrayList<>();
-                    for (URI location : locations) {
-                        File iter = new File(location);
-                        if (iter.isDirectory()) {
-                            Iterator<File> allFiles2 = FileUtils.iterateFiles(iter, null, true);
-                            while (allFiles2.hasNext())
-                                allFiles.add(allFiles2.next());
-                        }
-
-                        else
-                            allFiles.add(iter);
-                    }
-
-                    iter = allFiles.iterator();
-                } else {
-                    File curr = new File(locations[0]);
-                    if (curr.isDirectory())
-                        iter = FileUtils.iterateFiles(curr, null, true);
-                    else
-                        iter = Collections.singletonList(curr).iterator();
-                }
-            }
-        }
-
-
-        else if (split instanceof InputStreamInputSplit) {
-            record = new ArrayList<>();
-            InputStreamInputSplit split2 = (InputStreamInputSplit) split;
-            InputStream is = split2.getIs();
-            URI[] locations = split2.locations();
-            if (appendLabel) {
-                Path path = Paths.get(locations[0]);
-                String parent = path.getParent().toString();
-                record.add(new DoubleWritable(labels.indexOf(parent)));
-            }
-
-            is.close();
-        }
-
-    }
-
-    @Override
-    public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
-        this.conf = conf;
-        this.appendLabel = conf.getBoolean(APPEND_LABEL, false);
-        this.labels = new ArrayList<>(conf.getStringCollection(LABELS));
-        initialize(split);
-    }
-
-    @Override
-    public List<Writable> next() {
-        if (iter != null) {
-            File next = iter.next();
-            invokeListeners(next);
-            Wave wave = new Wave(next.getAbsolutePath());
-            return RecordUtils.toRecord(wave.getNormalizedAmplitudes());
-        } else if (record != null) {
-            hitImage = true;
-            return record;
-        }
-
-        throw new IllegalStateException("Indeterminant state: record must not be null, or a file iterator must exist");
-    }
-
-    @Override
-    public boolean hasNext() {
-        if (iter != null) {
-            return iter.hasNext();
-        } else if (record != null) {
-            return !hitImage;
-        }
-        throw new IllegalStateException("Indeterminant state: record must not be null, or a file iterator must exist");
-    }
-
-
-    @Override
-    public void close() throws IOException {
-
-    }
-
-    @Override
-    public void setConf(Configuration conf) {
-        this.conf = conf;
-    }
-
-    @Override
-    public Configuration getConf() {
-        return conf;
-    }
-
-    @Override
-    public List<String> getLabels() {
-        return null;
-    }
-
-
-    @Override
-    public void reset() {
-        if (inputSplit == null)
-            throw new UnsupportedOperationException("Cannot reset without first initializing");
-        try {
-            initialize(inputSplit);
-        } catch (Exception e) {
-            throw new RuntimeException("Error during LineRecordReader reset", e);
-        }
-
-    }
-
-    @Override
-    public List<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException {
-        invokeListeners(uri);
-        Wave wave = new Wave(dataInputStream);
+    protected List<Writable> loadData(File file, InputStream inputStream) throws IOException {
+        Wave wave = inputStream != null ? new Wave(inputStream) : new Wave(file.getAbsolutePath());
         return RecordUtils.toRecord(wave.getNormalizedAmplitudes());
     }
 
-    @Override
-    public Record nextRecord() {
-        return new org.datavec.api.records.impl.Record(next(), null);
-    }
-
-    @Override
-    public Record loadFromMetaData(RecordMetaData recordMetaData) throws IOException {
-        throw new UnsupportedOperationException("Loading from metadata not yet implemented");
-    }
-
-    @Override
-    public List<Record> loadFromMetaData(List<RecordMetaData> recordMetaDatas) throws IOException {
-        throw new UnsupportedOperationException("Loading from metadata not yet implemented");
-    }
 }

--- a/datavec-data/datavec-data-audio/src/test/java/org/datavec/audio/AudioReaderTest.java
+++ b/datavec-data/datavec-data-audio/src/test/java/org/datavec/audio/AudioReaderTest.java
@@ -1,0 +1,63 @@
+/*-
+ *  * Copyright 2017 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.audio;
+
+import static org.junit.Assert.*;
+
+import org.bytedeco.javacv.FFmpegFrameRecorder;
+import org.bytedeco.javacv.Frame;
+import org.datavec.api.records.reader.RecordReader;
+import org.datavec.api.split.FileSplit;
+import org.datavec.api.writable.Writable;
+import org.datavec.audio.recordreader.NativeAudioRecordReader;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.ShortBuffer;
+import java.util.List;
+
+import static org.bytedeco.javacpp.avcodec.*;
+
+/**
+ * @author saudet
+ */
+public class AudioReaderTest {
+    @Ignore
+    @Test
+    public void testNativeAudioReader() throws Exception {
+        File tempFile = File.createTempFile("testNativeAudioReader", ".ogg");
+        FFmpegFrameRecorder recorder = new FFmpegFrameRecorder(tempFile, 2);
+        recorder.setAudioCodec(AV_CODEC_ID_VORBIS);
+        recorder.setSampleRate(44100);
+        recorder.start();
+        Frame audioFrame = new Frame();
+        ShortBuffer audioBuffer = ShortBuffer.allocate(64 * 1024);
+        audioFrame.sampleRate = 44100;
+        audioFrame.audioChannels = 2;
+        audioFrame.samples = new ShortBuffer[] {audioBuffer};
+        recorder.record(audioFrame);
+        recorder.stop();
+        recorder.release();
+
+        RecordReader reader = new NativeAudioRecordReader();
+        reader.initialize(new FileSplit(tempFile));
+        assertTrue(reader.hasNext());
+        List<Writable> record = reader.next();
+        assertEquals(audioBuffer.limit(), record.size());
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor most of `WavFileRecordReader` into `BaseRecordReader` and reuse for `NativeAudioRecordReader`, which can read more than WAV files.

Also fixes #153 by replacing the check for `FileInput` with `BaseInputSplit`.

## How was this patch tested?

Unit test created and passing.