### PR TITLE
Disable default automatic update of SNAPSHOT artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,21 @@
         <stream.analytics.version>2.7.0</stream.analytics.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `<updatePolicy>never</updatePolicy>` on the SNAPSHOT repository to prevent interference with locally installed artifacts. They can still be pulled manually with `mvn -U ...`.

## How was this patch tested?

Build passes and SNAPSHOT artifacts do not get updated automatically anymore.