### PR TITLE
Minor API changes to RecordReader

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/BaseRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/BaseRecordReader.java
@@ -18,6 +18,7 @@ package org.datavec.api.records.reader;
 import java.util.*;
 
 import org.datavec.api.records.listener.RecordListener;
+import org.datavec.api.writable.Writable;
 
 /**
  * Manages record listeners.
@@ -50,4 +51,14 @@ public abstract class BaseRecordReader implements RecordReader {
         setListeners(Arrays.asList(listeners));
     }
 
+
+    @Override
+    public boolean batchesSupported() {
+        return false;
+    }
+
+    @Override
+    public List<Writable> next(int num) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/RecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/RecordReader.java
@@ -64,11 +64,27 @@ public interface RecordReader extends Closeable, Serializable, Configurable {
     void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException;
 
     /**
+     * This method returns true, if next(int) signature is supported by this RecordReader implementation.
+     *
+     * @return
+     */
+    boolean batchesSupported();
+
+    /**
+     * This method will be used, if batchesSupported() returns true.
+     *
+     * @param num
+     * @return
+     */
+    List<Writable> next(int num);
+
+    /**
      * Get the next record
      *
      * @return
      */
     List<Writable> next();
+
 
 
     /**

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemoryRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemoryRecordReader.java
@@ -59,6 +59,16 @@ public class InMemoryRecordReader implements RecordReader {
 
     }
 
+    @Override
+    public boolean batchesSupported() {
+        return false;
+    }
+
+    @Override
+    public List<Writable> next(int num) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Get the next record
      *

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemorySequenceRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemorySequenceRecordReader.java
@@ -64,6 +64,16 @@ public class InMemorySequenceRecordReader implements SequenceRecordReader {
         return iter.next();
     }
 
+    @Override
+    public boolean batchesSupported() {
+        return false;
+    }
+
+    @Override
+    public List<Writable> next(int num) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Load a sequence record from the given DataInputStream
      * Unlike {@link #next()} the internal state of the RecordReader is not modified

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
@@ -54,6 +54,16 @@ public class TransformProcessRecordReader implements RecordReader {
 
     }
 
+    @Override
+    public boolean batchesSupported() {
+        return false;
+    }
+
+    @Override
+    public List<Writable> next(int num) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Get the next record
      *

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessSequenceRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessSequenceRecordReader.java
@@ -59,6 +59,16 @@ public class TransformProcessSequenceRecordReader implements SequenceRecordReade
         return transformProcess.executeSequence(sequenceRecordReader.sequenceRecord());
     }
 
+    @Override
+    public boolean batchesSupported() {
+        return false;
+    }
+
+    @Override
+    public List<Writable> next(int num) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Load a sequence record from the given DataInputStream
      * Unlike {@link #next()} the internal state of the RecordReader is not modified

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -32,6 +32,7 @@ import org.datavec.image.data.ImageWritable;
 import org.datavec.image.transform.ImageTransform;
 import org.nd4j.linalg.api.concurrency.AffinityManager;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.ArrayUtil;
 
@@ -239,6 +240,205 @@ public class NativeImageLoader extends BaseImageLoader {
         return array;
     }
 
+
+    protected void fillNDArray(Mat image, INDArray ret) {
+        int rows = image.rows();
+        int cols = image.cols();
+        int channels = image.channels();
+
+        if (ret.lengthLong() != rows * cols * channels) {
+            throw new ND4JIllegalStateException("INDArray provided to store image not equal to image: {channels: "+ channels+", rows: "+rows+", columns: "+ cols+"}");
+        }
+
+        Indexer idx = image.createIndexer();
+        Pointer pointer = ret.data().pointer();
+        int[] stride = ret.stride();
+        boolean done = false;
+        if (pointer instanceof FloatPointer) {
+            FloatIndexer retidx = FloatIndexer.create((FloatPointer) pointer, new long[] {channels, rows, cols},
+                    new long[] {stride[0], stride[1], stride[2]});
+            if (idx instanceof UByteIndexer) {
+                UByteIndexer ubyteidx = (UByteIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, ubyteidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            } else if (idx instanceof UShortIndexer) {
+                UShortIndexer ushortidx = (UShortIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, ushortidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            } else if (idx instanceof IntIndexer) {
+                IntIndexer intidx = (IntIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, intidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            } else if (idx instanceof FloatIndexer) {
+                FloatIndexer floatidx = (FloatIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, floatidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            }
+        } else if (pointer instanceof DoublePointer) {
+            DoubleIndexer retidx = DoubleIndexer.create((DoublePointer) pointer, new long[] {channels, rows, cols},
+                    new long[] {stride[0], stride[1], stride[2]});
+            if (idx instanceof UByteIndexer) {
+                UByteIndexer ubyteidx = (UByteIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, ubyteidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            } else if (idx instanceof UShortIndexer) {
+                UShortIndexer ushortidx = (UShortIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, ushortidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            } else if (idx instanceof IntIndexer) {
+                IntIndexer intidx = (IntIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, intidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            } else if (idx instanceof FloatIndexer) {
+                FloatIndexer floatidx = (FloatIndexer) idx;
+                for (int k = 0; k < channels; k++) {
+                    for (int i = 0; i < rows; i++) {
+                        for (int j = 0; j < cols; j++) {
+                            retidx.put(k, i, j, floatidx.get(i, j, k));
+                        }
+                    }
+                }
+                done = true;
+            }
+        }
+        if (!done) {
+            for (int k = 0; k < channels; k++) {
+                for (int i = 0; i < rows; i++) {
+                    for (int j = 0; j < cols; j++) {
+                        if (channels > 1) {
+                            ret.putScalar(k, i, j, idx.getDouble(i, j, k));
+                        } else {
+                            ret.putScalar(i, j, idx.getDouble(i, j));
+                        }
+                    }
+                }
+            }
+        }
+
+        image.data();
+        Nd4j.getAffinityManager().tagLocation(ret, AffinityManager.Location.HOST);
+    }
+
+    public void asMatrixView(InputStream is, INDArray view) throws IOException {
+        byte[] bytes = IOUtils.toByteArray(is);
+        Mat image = imdecode(new Mat(bytes), CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
+        if (image == null || image.empty()) {
+            PIX pix = pixReadMem(bytes, bytes.length);
+            if (pix == null) {
+                throw new IOException("Could not decode image from input stream");
+            }
+            image = convert(pix);
+            pixDestroy(pix);
+        }
+        asMatrixView(image, view);
+    }
+
+    public void asMatrixView(File f, INDArray view) throws IOException {
+        try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(f))) {
+            asMatrixView(bis, view);
+        }
+    }
+
+    public void asMatrixView(Mat image, INDArray view) throws IOException {
+        if (imageTransform != null && converter != null) {
+            ImageWritable writable = new ImageWritable(converter.convert(image));
+            writable = imageTransform.transform(writable);
+            image = converter.convert(writable.getFrame());
+        }
+
+        if (channels > 0 && image.channels() != channels) {
+            int code = -1;
+            switch (image.channels()) {
+                case 1:
+                    switch (channels) {
+                        case 3:
+                            code = CV_GRAY2BGR;
+                            break;
+                        case 4:
+                            code = CV_GRAY2RGBA;
+                            break;
+                    }
+                    break;
+                case 3:
+                    switch (channels) {
+                        case 1:
+                            code = CV_BGR2GRAY;
+                            break;
+                        case 4:
+                            code = CV_BGR2RGBA;
+                            break;
+                    }
+                    break;
+                case 4:
+                    switch (channels) {
+                        case 1:
+                            code = CV_RGBA2GRAY;
+                            break;
+                        case 3:
+                            code = CV_RGBA2BGR;
+                            break;
+                    }
+                    break;
+            }
+            if (code < 0) {
+                throw new IOException("Cannot convert from " + image.channels() + " to " + channels + " channels.");
+            }
+            Mat newimage = new Mat();
+            cvtColor(image, newimage, code);
+            image = newimage;
+        }
+        if (centerCropIfNeeded) {
+            image = centerCropIfNeeded(image);
+        }
+        image = scalingIfNeed(image);
+
+        fillNDArray(image, view);
+
+        image.data();
+    }
+
     public INDArray asMatrix(Mat image) throws IOException {
         if (imageTransform != null && converter != null) {
             ImageWritable writable = new ImageWritable(converter.convert(image));
@@ -295,115 +495,11 @@ public class NativeImageLoader extends BaseImageLoader {
         int rows = image.rows();
         int cols = image.cols();
         int channels = image.channels();
-        Indexer idx = image.createIndexer();
         INDArray ret = Nd4j.create(channels, rows, cols);
-        Pointer pointer = ret.data().pointer();
-        int[] stride = ret.stride();
-        boolean done = false;
-        if (pointer instanceof FloatPointer) {
-            FloatIndexer retidx = FloatIndexer.create((FloatPointer) pointer, new long[] {channels, rows, cols},
-                            new long[] {stride[0], stride[1], stride[2]});
-            if (idx instanceof UByteIndexer) {
-                UByteIndexer ubyteidx = (UByteIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, ubyteidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            } else if (idx instanceof UShortIndexer) {
-                UShortIndexer ushortidx = (UShortIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, ushortidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            } else if (idx instanceof IntIndexer) {
-                IntIndexer intidx = (IntIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, intidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            } else if (idx instanceof FloatIndexer) {
-                FloatIndexer floatidx = (FloatIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, floatidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            }
-        } else if (pointer instanceof DoublePointer) {
-            DoubleIndexer retidx = DoubleIndexer.create((DoublePointer) pointer, new long[] {channels, rows, cols},
-                            new long[] {stride[0], stride[1], stride[2]});
-            if (idx instanceof UByteIndexer) {
-                UByteIndexer ubyteidx = (UByteIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, ubyteidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            } else if (idx instanceof UShortIndexer) {
-                UShortIndexer ushortidx = (UShortIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, ushortidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            } else if (idx instanceof IntIndexer) {
-                IntIndexer intidx = (IntIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, intidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            } else if (idx instanceof FloatIndexer) {
-                FloatIndexer floatidx = (FloatIndexer) idx;
-                for (int k = 0; k < channels; k++) {
-                    for (int i = 0; i < rows; i++) {
-                        for (int j = 0; j < cols; j++) {
-                            retidx.put(k, i, j, floatidx.get(i, j, k));
-                        }
-                    }
-                }
-                done = true;
-            }
-        }
-        if (!done) {
-            for (int k = 0; k < channels; k++) {
-                for (int i = 0; i < rows; i++) {
-                    for (int j = 0; j < cols; j++) {
-                        if (channels > 1) {
-                            ret.putScalar(k, i, j, idx.getDouble(i, j, k));
-                        } else {
-                            ret.putScalar(i, j, idx.getDouble(i, j));
-                        }
-                    }
-                }
-            }
-        }
+
+        fillNDArray(image, ret);
+
         image.data(); // dummy call to make sure it does not get deallocated prematurely
-        Nd4j.getAffinityManager().tagLocation(ret, AffinityManager.Location.HOST);
         return ret.reshape(ArrayUtil.combine(new int[] {1}, ret.shape()));
     }
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -278,7 +278,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
             cnt++;
         }
 
-        INDArray features = Nd4j.createUninitialized(new int[]{cnt, channels, height, width});
+        INDArray features = Nd4j.createUninitialized(new int[]{cnt, channels, height, width}, 'c');
         Nd4j.getAffinityManager().tagLocation(features, AffinityManager.Location.HOST);
         for(int i = 0; i < cnt; i++) {
             try {
@@ -292,7 +292,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
 
         List<Writable> ret = (RecordConverter.toRecord(features));
         if (appendLabel) {
-            INDArray labels = Nd4j.create(cnt, numCategories);
+            INDArray labels = Nd4j.create(cnt, numCategories, 'c');
             Nd4j.getAffinityManager().tagLocation(labels, AffinityManager.Location.HOST);
             for (int i = 0; i < currLabels.size(); i++) {
                 labels.putScalar(i, currLabels.get(i), 1.0f);

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -217,6 +217,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
             try {
                 invokeListeners(image);
                 INDArray row = imageLoader.asMatrix(image);
+                Nd4j.getAffinityManager().ensureLocation(row, AffinityManager.Location.DEVICE);
                 ret = RecordConverter.toRecord(row);
                 if (appendLabel)
                     ret.add(new IntWritable(labels.indexOf(getLabel(image.getPath()))));
@@ -286,6 +287,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
                 throw new RuntimeException(e);
             }
         }
+        Nd4j.getAffinityManager().ensureLocation(features, AffinityManager.Location.DEVICE);
 
 
         List<Writable> ret = (RecordConverter.toRecord(features));

--- a/datavec-dataframe/dependency-reduced-pom.xml
+++ b/datavec-dataframe/dependency-reduced-pom.xml
@@ -93,6 +93,10 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>snakeyaml</artifactId>
           <groupId>org.yaml</groupId>
         </exclusion>

--- a/datavec-dataframe/pom.xml
+++ b/datavec-dataframe/pom.xml
@@ -114,6 +114,12 @@
             <artifactId>jfairy</artifactId>
             <version>0.5.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>


### PR DESCRIPTION
Minor API change to RecordReader:
- batchesSupported() 
- next(num)

This method provides List<Writable> that contains whole batch at once, so DataSet.merge() call isn't needed