### PR TITLE
modify transform endpoints

### DIFF
--- a/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
+++ b/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
@@ -88,7 +88,7 @@ public class CSVSparkTransformServer {
         })));
 
         //return the host information for a given id
-        routingDsl.POST("/transform").routeTo(FunctionUtil.function0((() -> {
+        routingDsl.POST("/transformincremental").routeTo(FunctionUtil.function0((() -> {
             try {
                 CSVRecord record = Json.fromJson(request().body().asJson(), CSVRecord.class);
                 if (record == null)
@@ -101,7 +101,7 @@ public class CSVSparkTransformServer {
         })));
 
         //return the host information for a given id
-        routingDsl.POST("/transformbatch").routeTo(FunctionUtil.function0((() -> {
+        routingDsl.POST("/transform").routeTo(FunctionUtil.function0((() -> {
             try {
                 BatchRecord batch = transform.transform(Json.fromJson(request().body().asJson(), BatchRecord.class));
                 if (batch == null)
@@ -112,7 +112,19 @@ public class CSVSparkTransformServer {
                 return internalServerError();
             }
         })));
-        routingDsl.POST("/transformedbatcharray").routeTo(FunctionUtil.function0((() -> {
+
+        routingDsl.POST("/transformedincrementalarray").routeTo(FunctionUtil.function0((() -> {
+            try {
+                CSVRecord record = Json.fromJson(request().body().asJson(), CSVRecord.class);
+                if (record == null)
+                    return badRequest();
+                return ok(Json.toJson(transform.toArray(record)));
+            } catch (Exception e) {
+                return internalServerError();
+            }
+        })));
+
+        routingDsl.POST("/transformedarray").routeTo(FunctionUtil.function0((() -> {
             try {
                 BatchRecord batchRecord = Json.fromJson(request().body().asJson(), BatchRecord.class);
                 if (batchRecord == null)
@@ -123,19 +135,7 @@ public class CSVSparkTransformServer {
             }
         })));
 
-        routingDsl.POST("/transformedarray").routeTo(FunctionUtil.function0((() -> {
-            try {
-                CSVRecord record = Json.fromJson(request().body().asJson(), CSVRecord.class);
-                if (record == null)
-                    return badRequest();
-                return ok(Json.toJson(transform.toArray(record)));
-            } catch (Exception e) {
-                return internalServerError();
-            }
-        })));
         server = Server.forRouter(routingDsl.build(), Mode.DEV, port);
-
-
     }
 
     /**

--- a/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformServerTest.java
+++ b/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformServerTest.java
@@ -75,23 +75,23 @@ public class CSVSparkTransformServerTest {
     public void testServer() throws Exception {
         String[] values = new String[] {"1.0", "2.0"};
         CSVRecord record = new CSVRecord(values);
-        JsonNode jsonNode = Unirest.post("http://localhost:9050/transform").header("accept", "application/json")
+        JsonNode jsonNode = Unirest.post("http://localhost:9050/transformincremental").header("accept", "application/json")
                         .header("Content-Type", "application/json").body(record).asJson().getBody();
-        CSVRecord csvRecord = Unirest.post("http://localhost:9050/transform").header("accept", "application/json")
+        CSVRecord csvRecord = Unirest.post("http://localhost:9050/transformincremental").header("accept", "application/json")
                         .header("Content-Type", "application/json").body(record).asObject(CSVRecord.class).getBody();
 
         BatchRecord batchRecord = new BatchRecord();
         for (int i = 0; i < 3; i++)
             batchRecord.add(csvRecord);
-        BatchRecord batchRecord1 = Unirest.post("http://localhost:9050/transformbatch")
+        BatchRecord batchRecord1 = Unirest.post("http://localhost:9050/transform")
                         .header("accept", "application/json").header("Content-Type", "application/json")
                         .body(batchRecord).asObject(BatchRecord.class).getBody();
 
-        Base64NDArrayBody array = Unirest.post("http://localhost:9050/transformedarray")
+        Base64NDArrayBody array = Unirest.post("http://localhost:9050/transformedincrementalarray")
                         .header("accept", "application/json").header("Content-Type", "application/json").body(record)
                         .asObject(Base64NDArrayBody.class).getBody();
 
-        Base64NDArrayBody batchArray1 = Unirest.post("http://localhost:9050/transformedbatcharray")
+        Base64NDArrayBody batchArray1 = Unirest.post("http://localhost:9050/transformedarray")
                         .header("accept", "application/json").header("Content-Type", "application/json")
                         .body(batchRecord).asObject(Base64NDArrayBody.class).getBody();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

as discussed with @huitseeker 
I modified `CSVSparkTransformServer`
- /transformincremental : deal with a **single** record and return **transformed** record
- /transform : deal with a **batchRecord** and return **transformed** record
- /transformedincrementalarray : deal with a **single** record and return **64ed ndarray**
- /transformedarray : deal with a **batchRecord** and return **64ed ndarray**

https://github.com/SkymindIO/lagom-skil-api/issues/167

## How was this patch tested?

Test code(CSVSparkTransformServerTest) included

/cc @huitseeker 