### PR TITLE
CSVRecordReader now overrides hasNext()

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -95,8 +95,7 @@ public class CSVRecordReader extends LineRecordReader {
         this.quote = conf.get(QUOTE, null);
     }
 
-    @Override
-    public boolean hasNext() {
+    private boolean skipLines() {
         if (!skippedLines && skipNumLines > 0) {
             for (int i = 0; i < skipNumLines; i++) {
                 if (!super.hasNext()) {
@@ -106,20 +105,18 @@ public class CSVRecordReader extends LineRecordReader {
             }
             skippedLines = true;
         }
-        return super.hasNext();
+        return true;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return skipLines() && super.hasNext();
     }
 
     @Override
     public List<Writable> next() {
-        if (!skippedLines && skipNumLines > 0) {
-            for (int i = 0; i < skipNumLines; i++) {
-                if (!hasNext()) {
-                    return new ArrayList<>();
-                }
-                super.next();
-            }
-            skippedLines = true;
-        }
+        if (!skipLines())
+            return new ArrayList<>();
         Text t = (Text) super.next().iterator().next();
         String val = t.toString();
         return parseLine(val);

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -18,20 +18,17 @@ package org.datavec.api.records.reader.impl.csv;
 
 
 
-import org.apache.commons.io.IOUtils;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.Record;
 import org.datavec.api.records.metadata.RecordMetaData;
 import org.datavec.api.records.metadata.RecordMetaDataLine;
 import org.datavec.api.records.reader.impl.LineRecordReader;
-import org.datavec.api.split.StringSplit;
 import org.datavec.api.writable.Text;
 import org.datavec.api.split.InputSplit;
 import org.datavec.api.writable.Writable;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.*;
 

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -113,7 +113,7 @@ public class CSVRecordReader extends LineRecordReader {
     @Override
     public List<Writable> next() {
         if (!skipLines())
-            return new ArrayList<>();
+            throw new NoSuchElementException("No next element found!");
         Text t = (Text) super.next().iterator().next();
         String val = t.toString();
         return parseLine(val);

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -18,17 +18,20 @@ package org.datavec.api.records.reader.impl.csv;
 
 
 
+import org.apache.commons.io.IOUtils;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.Record;
 import org.datavec.api.records.metadata.RecordMetaData;
 import org.datavec.api.records.metadata.RecordMetaDataLine;
 import org.datavec.api.records.reader.impl.LineRecordReader;
+import org.datavec.api.split.StringSplit;
 import org.datavec.api.writable.Text;
 import org.datavec.api.split.InputSplit;
 import org.datavec.api.writable.Writable;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.*;
 
@@ -90,6 +93,20 @@ public class CSVRecordReader extends LineRecordReader {
         this.skipNumLines = conf.getInt(SKIP_NUM_LINES, this.skipNumLines);
         this.delimiter = conf.get(DELIMITER, DEFAULT_DELIMITER);
         this.quote = conf.get(QUOTE, null);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!skippedLines && skipNumLines > 0) {
+            for (int i = 0; i < skipNumLines; i++) {
+                if (!super.hasNext()) {
+                    return false;
+                }
+                super.next();
+            }
+            skippedLines = true;
+        }
+        return super.hasNext();
     }
 
     @Override

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -251,7 +251,6 @@ public class CSVRecordReaderTest {
         rr.initialize(new FileSplit(tempFile));
         rr.reset();
         assertTrue(!rr.hasNext());
-        rr.reset();
         rr.next();
     }
 

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -36,7 +36,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.*;
 
@@ -233,14 +235,42 @@ public class CSVRecordReaderTest {
         }
     }
 
-    @Test
-    public void testCsvWithHeaderOnly() throws IOException, InterruptedException {
-        String header = "one,two,three\n";
-        File tempFile = File.createTempFile("csvWithHeaderOnly", ".csv");
-        FileUtils.write(tempFile, header, "utf-8");
+    @Test(expected=NoSuchElementException.class)
+    public void testCsvSkipAllLines() throws IOException, InterruptedException {
+        final int numLines = 4;
+        final List<Writable> lineList = Arrays.asList((Writable) new IntWritable(numLines-1), (Writable) new Text("one"),
+                                                      (Writable) new Text("two"), (Writable) new Text("three"));
+        String header = ",one,two,three";
+        List<String> lines = new ArrayList<>();
+        for (int i = 0; i < numLines; i++)
+            lines.add(Integer.toString(i) + header);
+        File tempFile = File.createTempFile("csvSkipLines", ".csv");
+        FileUtils.writeLines(tempFile, lines);
 
-        CSVRecordReader rr = new CSVRecordReader(1, ",");
+        CSVRecordReader rr = new CSVRecordReader(numLines, ",");
         rr.initialize(new FileSplit(tempFile));
-        assert(!rr.hasNext());
+        rr.reset();
+        assertTrue(!rr.hasNext());
+        rr.reset();
+        rr.next();
+    }
+
+    @Test
+    public void testCsvSkipAllButOneLine() throws IOException, InterruptedException {
+        final int numLines = 4;
+        final List<Writable> lineList = Arrays.asList((Writable) new Text(Integer.toString(numLines-1)), (Writable) new Text("one"),
+                                                      (Writable) new Text("two"), (Writable) new Text("three"));
+        String header = ",one,two,three";
+        List<String> lines = new ArrayList<>();
+        for (int i = 0; i < numLines; i++)
+            lines.add(Integer.toString(i) + header);
+        File tempFile = File.createTempFile("csvSkipLines", ".csv");
+        FileUtils.writeLines(tempFile, lines);
+
+        CSVRecordReader rr = new CSVRecordReader(numLines-1, ",");
+        rr.initialize(new FileSplit(tempFile));
+        rr.reset();
+        assertTrue(rr.hasNext());
+        assertEquals(rr.next(), lineList);
     }
 }

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -241,6 +241,6 @@ public class CSVRecordReaderTest {
 
         CSVRecordReader rr = new CSVRecordReader(1, ",");
         rr.initialize(new FileSplit(tempFile));
-        rr.next();
+        assert(!rr.hasNext());
     }
 }

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -31,6 +31,8 @@ import org.datavec.api.util.ClassPathResource;
 import org.datavec.api.writable.Writable;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -231,4 +233,14 @@ public class CSVRecordReaderTest {
         }
     }
 
+    @Test
+    public void testCsvWithHeaderOnly() throws IOException, InterruptedException {
+        String header = "one,two,three\n";
+        File tempFile = File.createTempFile("csvWithHeaderOnly", ".csv");
+        FileUtils.write(tempFile, header, "utf-8");
+
+        CSVRecordReader rr = new CSVRecordReader(1, ",");
+        rr.initialize(new FileSplit(tempFile));
+        rr.next();
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

CSVRecordReader needs to override hasNext() rather than inherit it from LineRecordReader. This is because CSVRecordReader can skip >0 lines, while LineRecordReader cannot. Thus, for CSVs with N lines where we skip N lines, e.g., a CSV with only a header, hasNext() will return true (LineRecordReader sees the header), but next() will throw an exception because CSVRecordReader skips it and then cannot find any non-header lines.

(Please fill in changes proposed in this fix)

## How was this patch tested?

All CSVRecordReader unit tests pass, and I added an additional test to make sure that hasNext() returns false when we skip all lines.

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
