### PR TITLE
MapFile record reader + test fixes

### DIFF
--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileRecordReader.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileRecordReader.java
@@ -137,6 +137,9 @@ public class MapFileRecordReader implements RecordReader {
             mapFilePartRootDirectories.add(partRootDir.getAbsolutePath());
         }
 
+        //Sort the paths so we iterate over multi-part MapFiles like part-r-00000, part-r-00001, etc when not randomized
+        Collections.sort(mapFilePartRootDirectories);
+
 
         if (dataUris.size() == 1) {
             //Just parent of /data

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileSequenceRecordReader.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileSequenceRecordReader.java
@@ -139,6 +139,9 @@ public class MapFileSequenceRecordReader implements SequenceRecordReader {
             mapFilePartRootDirectories.add(partRootDir.getAbsolutePath());
         }
 
+        //Sort the paths so we iterate over multi-part MapFiles like part-r-00000, part-r-00001, etc when not randomized
+        Collections.sort(mapFilePartRootDirectories);
+
 
         if (dataUris.size() == 1) {
             //Just parent of /data

--- a/datavec-spark/src/test/java/org/datavec/spark/storage/TestSparkStorageUtils.java
+++ b/datavec-spark/src/test/java/org/datavec/spark/storage/TestSparkStorageUtils.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Alex on 30/05/2017.
@@ -73,10 +74,9 @@ public class TestSparkStorageUtils extends BaseSparkTest {
         SparkStorageUtils.saveSequenceFile(path, rdd);
         List<List<Writable>> restored2 = SparkStorageUtils.restoreSequenceFile(path, sc).collect();
 
+        //Sequence file loading + collect iteration order is not guaranteed (depends on number of partitions, etc)
         assertEquals(3, restored2.size());
-        for( int i=0; i<3; i++ ){
-            assertEquals(l.get(i), restored2.get(i));
-        }
+        assertTrue(l.containsAll(restored2) && restored2.containsAll(l));
     }
 
     @Test
@@ -126,10 +126,9 @@ public class TestSparkStorageUtils extends BaseSparkTest {
         SparkStorageUtils.saveSequenceFileSequences(path, rdd);
         List<List<List<Writable>>> restored2 = SparkStorageUtils.restoreSequenceFileSequences(path, sc).collect();
 
+        //Sequence file loading + collect iteration order is not guaranteed (depends on number of partitions, etc)
         assertEquals(3, restored2.size());
-        for( int i=0; i<3; i++ ){
-            assertEquals(l.get(i), restored2.get(i));
-        }
+        assertTrue(l.containsAll(restored2) && restored2.containsAll(l));
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes:
https://github.com/deeplearning4j/DataVec/issues/303
https://github.com/deeplearning4j/DataVec/issues/305

## How was this patch tested?

Initially all tests passed on Windows, tests flagged in #303 and #305 were confirmed to fail on Linux only (due to file iteration order in the first case, and *probably* the same reason (though ultimately was bad test assumption regarding iteration orders) in the second).
Confirmed fixed + tests passing on both platforms.
