### PR TITLE
improve endpoints(consistency perspective)

### DIFF
--- a/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
+++ b/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
@@ -113,7 +113,7 @@ public class CSVSparkTransformServer {
             }
         })));
 
-        routingDsl.POST("/transformedincrementalarray").routeTo(FunctionUtil.function0((() -> {
+        routingDsl.POST("/transformincrementalarray").routeTo(FunctionUtil.function0((() -> {
             try {
                 CSVRecord record = Json.fromJson(request().body().asJson(), CSVRecord.class);
                 if (record == null)
@@ -124,7 +124,7 @@ public class CSVSparkTransformServer {
             }
         })));
 
-        routingDsl.POST("/transformedarray").routeTo(FunctionUtil.function0((() -> {
+        routingDsl.POST("/transformarray").routeTo(FunctionUtil.function0((() -> {
             try {
                 BatchRecord batchRecord = Json.fromJson(request().body().asJson(), BatchRecord.class);
                 if (batchRecord == null)

--- a/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformServerNoJsonTest.java
+++ b/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformServerNoJsonTest.java
@@ -81,23 +81,23 @@ public class CSVSparkTransformServerNoJsonTest {
 
         String[] values = new String[] {"1.0", "2.0"};
         CSVRecord record = new CSVRecord(values);
-        JsonNode jsonNode = Unirest.post("http://localhost:9050/transform").header("accept", "application/json")
+        JsonNode jsonNode = Unirest.post("http://localhost:9050/transformincremental").header("accept", "application/json")
                         .header("Content-Type", "application/json").body(record).asJson().getBody();
-        CSVRecord csvRecord = Unirest.post("http://localhost:9050/transform").header("accept", "application/json")
+        CSVRecord csvRecord = Unirest.post("http://localhost:9050/transformincremental").header("accept", "application/json")
                         .header("Content-Type", "application/json").body(record).asObject(CSVRecord.class).getBody();
 
         BatchRecord batchRecord = new BatchRecord();
         for (int i = 0; i < 3; i++)
             batchRecord.add(csvRecord);
-        BatchRecord batchRecord1 = Unirest.post("http://localhost:9050/transformbatch")
+        BatchRecord batchRecord1 = Unirest.post("http://localhost:9050/transform")
                         .header("accept", "application/json").header("Content-Type", "application/json")
                         .body(batchRecord).asObject(BatchRecord.class).getBody();
 
-        Base64NDArrayBody array = Unirest.post("http://localhost:9050/transformedarray")
+        Base64NDArrayBody array = Unirest.post("http://localhost:9050/transformincrementalarray")
                         .header("accept", "application/json").header("Content-Type", "application/json").body(record)
                         .asObject(Base64NDArrayBody.class).getBody();
 
-        Base64NDArrayBody batchArray1 = Unirest.post("http://localhost:9050/transformedbatcharray")
+        Base64NDArrayBody batchArray1 = Unirest.post("http://localhost:9050/transformarray")
                         .header("accept", "application/json").header("Content-Type", "application/json")
                         .body(batchRecord).asObject(Base64NDArrayBody.class).getBody();
 

--- a/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformServerTest.java
+++ b/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformServerTest.java
@@ -87,11 +87,11 @@ public class CSVSparkTransformServerTest {
                         .header("accept", "application/json").header("Content-Type", "application/json")
                         .body(batchRecord).asObject(BatchRecord.class).getBody();
 
-        Base64NDArrayBody array = Unirest.post("http://localhost:9050/transformedincrementalarray")
+        Base64NDArrayBody array = Unirest.post("http://localhost:9050/transformincrementalarray")
                         .header("accept", "application/json").header("Content-Type", "application/json").body(record)
                         .asObject(Base64NDArrayBody.class).getBody();
 
-        Base64NDArrayBody batchArray1 = Unirest.post("http://localhost:9050/transformedarray")
+        Base64NDArrayBody batchArray1 = Unirest.post("http://localhost:9050/transformarray")
                         .header("accept", "application/json").header("Content-Type", "application/json")
                         .body(batchRecord).asObject(Base64NDArrayBody.class).getBody();
 

--- a/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformTest.java
+++ b/datavec-spark-inference-server/src/test/java/org/datavec/spark/transform/CSVSparkTransformTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Created by agibsonccc on 12/24/16.
  */
-public class CSVSparkTransformerTest {
+public class CSVSparkTransformTest {
     @Test
     public void testTransformer() throws Exception {
         List<Writable> input = new ArrayList<>();
@@ -41,7 +41,6 @@ public class CSVSparkTransformerTest {
         INDArray fromBase64 = Nd4jBase64.fromBase64(body.getNdarray());
         assertTrue(fromBase64.isVector());
         System.out.println("Base 64ed array " + fromBase64);
-
     }
 
     @Test
@@ -68,8 +67,5 @@ public class CSVSparkTransformerTest {
         INDArray fromBase64 = Nd4jBase64.fromBase64(body.getNdarray());
         assertTrue(fromBase64.isMatrix());
         System.out.println("Base 64ed array " + fromBase64);
-
     }
-
-
 }


### PR DESCRIPTION
to fix https://github.com/SkymindIO/lagom-skil-api/issues/187 issue

to keep consistency, we decided remove `ed` postfix
/transform~~ed~~incrementalarray: deal with single record and return base 64ed array
/transform~~ed~~array: deal with batch record and return base 64ed array

also updated test codes
