### PR TITLE
Update version of JavaCPP to 1.3.3-SNAPSHOT and JavaCV to 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,12 @@
         <logback.version>1.1.2</logback.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <reflections.version>0.9.10</reflections.version>
-        <opencv.version>3.1.0</opencv.version>
+        <opencv.version>3.2.0</opencv.version>
         <ffmpeg.version>3.2.1</ffmpeg.version>
         <leptonica.version>1.73</leptonica.version>
         <javacpp-presets.version>1.3</javacpp-presets.version>
-        <javacpp.version>1.3.2</javacpp.version>
-        <javacv.version>1.3.1</javacv.version>
+        <javacpp.version>1.3.3-SNAPSHOT</javacpp.version>
+        <javacv.version>1.3.2</javacv.version>
         <geoip2.version>2.8.1</geoip2.version>
         <stream.analytics.version>2.7.0</stream.analytics.version>
         <hadoop.version>2.2.0</hadoop.version>  <!-- Hadoop version used by Spark 1.6.2 and 2.2.1 (and likely others) -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use latest version of JavaCPP and JavaCV.

## How was this patch tested?

Unit tests pass.