### PR TITLE
make json use shaded jackson rather than plays version

### DIFF
--- a/datavec-spark-inference-parent/datavec-spark-inference-client/src/test/java/org/datavec/transform/client/DataVecTransformClientTest.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-client/src/test/java/org/datavec/transform/client/DataVecTransformClientTest.java
@@ -12,8 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.dataset.DataSet;
-import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.serde.base64.Nd4jBase64;
 
 import java.io.File;

--- a/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
@@ -11,6 +11,7 @@ import org.datavec.spark.transform.model.Base64NDArrayBody;
 import org.datavec.spark.transform.model.BatchRecord;
 import org.datavec.spark.transform.model.CSVRecord;
 import org.datavec.spark.transform.service.DataVecTransformService;
+import org.nd4j.shade.jackson.databind.ObjectMapper;
 import play.Mode;
 import play.libs.Json;
 import play.routing.RoutingDsl;
@@ -18,12 +19,9 @@ import play.server.Server;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 
 import static play.mvc.Controller.request;
-import static play.mvc.Results.badRequest;
-import static play.mvc.Results.internalServerError;
-import static play.mvc.Results.ok;
+import static play.mvc.Results.*;
 
 /**
  * A rest server for using an
@@ -45,6 +43,7 @@ public class CSVSparkTransformServer implements DataVecTransformService {
     private int port = 9000;
     private Server server;
     private CSVSparkTransform transform;
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     public void runMain(String[] args) throws Exception {
         JCommander jcmdr = new JCommander(this);
@@ -106,7 +105,7 @@ public class CSVSparkTransformServer implements DataVecTransformService {
         //return the host information for a given id
         routingDsl.POST("/transformincremental").routeTo(FunctionUtil.function0((() -> {
             try {
-                CSVRecord record = Json.fromJson(request().body().asJson(), CSVRecord.class);
+                CSVRecord record = objectMapper.readValue(request().body().asText(),CSVRecord.class);
                 if (record == null)
                     return badRequest();
                 return ok(Json.toJson(transformIncremental(record)));
@@ -119,7 +118,7 @@ public class CSVSparkTransformServer implements DataVecTransformService {
         //return the host information for a given id
         routingDsl.POST("/transform").routeTo(FunctionUtil.function0((() -> {
             try {
-                BatchRecord batch = transform(Json.fromJson(request().body().asJson(), BatchRecord.class));
+                BatchRecord batch = transform(objectMapper.readValue(request().body().asText(),BatchRecord.class));
                 if (batch == null)
                     return badRequest();
                 return ok(Json.toJson(batch));
@@ -131,7 +130,7 @@ public class CSVSparkTransformServer implements DataVecTransformService {
 
         routingDsl.POST("/transformincrementalarray").routeTo(FunctionUtil.function0((() -> {
             try {
-                CSVRecord record = Json.fromJson(request().body().asJson(), CSVRecord.class);
+                CSVRecord record =  objectMapper.readValue(request().body().asText(),CSVRecord.class);
                 if (record == null)
                     return badRequest();
                 return ok(Json.toJson(transformArrayIncremental(record)));
@@ -142,7 +141,7 @@ public class CSVSparkTransformServer implements DataVecTransformService {
 
         routingDsl.POST("/transformarray").routeTo(FunctionUtil.function0((() -> {
             try {
-                BatchRecord batchRecord = Json.fromJson(request().body().asJson(), BatchRecord.class);
+                BatchRecord batchRecord =  objectMapper.readValue(request().body().asText(),BatchRecord.class);
                 if (batchRecord == null)
                     return badRequest();
                 return ok(Json.toJson(transformArray(batchRecord)));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updates datavec to use new jackson rather than the old play jackson (had a bug in it related to writing raw values)
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
