### PR TITLE
WIP Mark IAggregableReduceOp as Serializable.

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/transform/ops/IAggregableReduceOp.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/ops/IAggregableReduceOp.java
@@ -1,12 +1,13 @@
 package org.datavec.api.transform.ops;
 
+import java.io.Serializable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
  * Created by huitseeker on 4/28/17.
  */
-public interface IAggregableReduceOp<T, V> extends Consumer<T>, Supplier<V> {
+public interface IAggregableReduceOp<T, V> extends Consumer<T>, Supplier<V>, Serializable {
 
     public <W extends IAggregableReduceOp<T, V>> void combine(W accu);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mark IAggregableReduceOp as Serializable to fix running Reducers on Spark.

## How was this patch tested?

Added a test that uses reflection to check that every ...Op or Aggregable... 
