### PR TITLE
Fix loading for some files by Leptonica

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -183,9 +183,9 @@ public class NativeImageLoader extends BaseImageLoader {
         Mat mat = new Mat(height, width, CV_8UC(channels), pix.data(), 4 * pix.wpl());
         Mat mat2 = new Mat(height, width, CV_8UC(channels));
         // swap bytes if needed
-        int[] swap = {0, 3, 1, 2, 2, 1, 3, 0}, copy = {0, 0, 1, 1, 2, 2, 3, 3},
+        int[] swap = {0, channels - 1, 1, channels - 2, 2, channels - 3, 3, channels - 4}, copy = {0, 0, 1, 1, 2, 2, 3, 3},
                         fromTo = channels > 1 && ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN) ? swap : copy;
-        mixChannels(mat, 1, mat2, 1, fromTo, fromTo.length / 2);
+        mixChannels(mat, 1, mat2, 1, fromTo, Math.min(channels, fromTo.length / 2));
         if (tempPix != null) {
             pixDestroy(tempPix);
         }

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -26,6 +26,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.bytedeco.javacpp.lept.*;
 import static org.bytedeco.javacpp.opencv_core.*;
 
 /**
@@ -35,6 +36,63 @@ import static org.bytedeco.javacpp.opencv_core.*;
 public class TestNativeImageLoader {
     static final long seed = 10;
     static final Random rng = new Random(seed);
+
+    @Test
+    public void testConvertPix() {
+        PIX pix;
+        Mat mat;
+
+        pix = pixCreate(11, 22, 1);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(11, mat.cols());
+        assertEquals(22, mat.rows());
+        assertEquals(CV_8UC1, mat.type());
+
+        pix = pixCreate(33, 44, 2);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(33, mat.cols());
+        assertEquals(44, mat.rows());
+        assertEquals(CV_8UC1, mat.type());
+
+        pix = pixCreate(55, 66, 4);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(55, mat.cols());
+        assertEquals(66, mat.rows());
+        assertEquals(CV_8UC1, mat.type());
+
+        pix = pixCreate(77, 88, 8);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(77, mat.cols());
+        assertEquals(88, mat.rows());
+        assertEquals(CV_8UC1, mat.type());
+
+        pix = pixCreate(99, 111, 16);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(99, mat.cols());
+        assertEquals(111, mat.rows());
+        assertEquals(CV_8UC2, mat.type());
+
+        pix = pixCreate(222, 333, 24);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(222, mat.cols());
+        assertEquals(333, mat.rows());
+        assertEquals(CV_8UC3, mat.type());
+
+        pix = pixCreate(444, 555, 32);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(444, mat.cols());
+        assertEquals(555, mat.rows());
+        assertEquals(CV_8UC4, mat.type());
+
+        // a GIF file, for example
+        pix = pixCreate(32, 32, 8);
+        PIXCMAP cmap = pixcmapCreateLinear(8, 256);
+        pixSetColormap(pix, cmap);
+        mat = NativeImageLoader.convert(pix);
+        assertEquals(32, mat.cols());
+        assertEquals(32, mat.rows());
+        assertEquals(CV_8UC4, mat.type());
+    }
 
     @Test
     public void testAsRowVector() throws Exception {


### PR DESCRIPTION
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/3550

## What changes were proposed in this pull request?

Fix the method that converts Leptonica PIX into OpenCV Mat, required for some data formats, such as 1 bpp TIFF files.

## How was this patch tested?

New unit test passes.