### PR TITLE
Consistent URI String formatting for FileRecordReader. Move to iterator of iterators.

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/FileRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/FileRecordReader.java
@@ -39,6 +39,7 @@ import java.util.*;
 public class FileRecordReader extends BaseRecordReader {
 
     protected Iterator<File> iter;
+    protected Iterator<String> locationsIterator;
     protected Configuration conf;
     protected File currentFile;
     protected List<String> labels;
@@ -55,7 +56,7 @@ public class FileRecordReader extends BaseRecordReader {
 
 
     protected void doInitialize(InputSplit split) {
-        URI[] locations = split.locations();
+        /*URI[] locations = split.locations();
 
         if (locations != null && locations.length >= 1) {
             if (locations.length > 1) {
@@ -91,7 +92,8 @@ public class FileRecordReader extends BaseRecordReader {
                 else
                     iter = Collections.singletonList(curr).iterator();
             }
-        }
+        }*/
+        locationsIterator = split.locationsPathIterator();
 
     }
 
@@ -140,6 +142,14 @@ public class FileRecordReader extends BaseRecordReader {
 
     @Override
     public boolean hasNext() {
+        if (iter.hasNext()) {
+            return true;
+        }
+        if (!locationsIterator.hasNext()) {
+            return false;
+        }
+        File file = new File(locationsIterator.next());
+        iter = FileUtils.iterateFiles(file, null, true);
         return iter != null && iter.hasNext();
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/regex/RegexSequenceRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/regex/RegexSequenceRecordReader.java
@@ -156,7 +156,7 @@ public class RegexSequenceRecordReader extends FileRecordReader implements Seque
 
     @Override
     public SequenceRecord nextSequence() {
-        File next = iter.next();
+        File next = this.nextFile();
 
         String fileContents;
         try {

--- a/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
@@ -106,7 +106,7 @@ public class FileSplit extends BaseInputSplit {
             }
         } else {
             // Lists one file
-            String toString = rootDir.toURI().toString(); //URI.getPath(), getRawPath() etc don't have file:/ prefix necessary for conversion back to URI
+            String toString = URIUtil.fileToURI(rootDir).toString(); //URI.getPath(), getRawPath() etc don't have file:/ prefix necessary for conversion back to URI
             uriStrings = Collections.singletonList(toString);
             length += rootDir.length();
         }

--- a/datavec-api/src/main/java/org/datavec/api/util/files/URIUtil.java
+++ b/datavec-api/src/main/java/org/datavec/api/util/files/URIUtil.java
@@ -15,7 +15,7 @@ public class URIUtil {
         try {
             // manually construct URI (this is faster)
             String sp = slashify(f.getAbsoluteFile().getPath(), false);
-            if (sp.startsWith("//"))
+            if (!sp.startsWith("//"))
                 sp = "//" + sp;
             return new URI("file", null, sp, null);
 

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVSequenceRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVSequenceRecordReaderTest.java
@@ -162,7 +162,7 @@ public class CSVSequenceRecordReaderTest {
             URI[] loc = locations();
             String[] arr = new String[loc.length];
             for (int i = 0; i < loc.length; i++) {
-                arr[i] = loc[i].getPath();
+                arr[i] = loc[i].toString();
             }
             return Arrays.asList(arr).iterator();
         }

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/RegexRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/RegexRecordReaderTest.java
@@ -107,7 +107,7 @@ public class RegexRecordReaderTest {
     public void testRegexSequenceRecordReader() throws Exception {
         String regex = "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (\\d+) ([A-Z]+) (.*)";
 
-        String path = new ClassPathResource("/logtestdata/logtestfile0.txt").getFile().getAbsolutePath();
+        String path = new ClassPathResource("/logtestdata/logtestfile0.txt").getFile().toURI().toString();
         path = path.replace("0", "%d");
 
         InputSplit is = new NumberedFileInputSplit(path, 0, 1);
@@ -147,9 +147,8 @@ public class RegexRecordReaderTest {
     public void testRegexSequenceRecordReaderMeta() throws Exception {
         String regex = "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (\\d+) ([A-Z]+) (.*)";
 
-        String path = new ClassPathResource("/logtestdata/logtestfile0.txt").getFile().getAbsolutePath();
+        String path = new ClassPathResource("/logtestdata/logtestfile0.txt").getFile().toURI().toString();
         path = path.replace("0", "%d");
-
         InputSplit is = new NumberedFileInputSplit(path, 0, 1);
 
         SequenceRecordReader rr = new RegexSequenceRecordReader(regex, 1);

--- a/datavec-data/datavec-data-codec/src/main/java/org/datavec/codec/reader/BaseCodecRecordReader.java
+++ b/datavec-data/datavec-data-codec/src/main/java/org/datavec/codec/reader/BaseCodecRecordReader.java
@@ -61,6 +61,9 @@ public abstract class BaseCodecRecordReader extends FileRecordReader implements 
 
     @Override
     public List<List<Writable>> sequenceRecord() {
+        if (iter == null || !iter.hasNext()) {
+            this.advanceToNextLocation();
+        }
         File next = iter.next();
 
         try {
@@ -95,11 +98,6 @@ public abstract class BaseCodecRecordReader extends FileRecordReader implements 
     }
 
     @Override
-    public boolean hasNext() {
-        return iter.hasNext();
-    }
-
-    @Override
     public void setConf(Configuration conf) {
         super.setConf(conf);
         startFrame = conf.getInt(START_FRAME, 0);
@@ -119,7 +117,7 @@ public abstract class BaseCodecRecordReader extends FileRecordReader implements 
 
     @Override
     public SequenceRecord nextSequence() {
-        File next = iter.next();
+        File next = this.nextFile();
 
         List<List<Writable>> list;
         try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The potentially breaking change is the addition of a requirement that 'uriStrings' always have a well formatted URIs, starting with 'file://', as it's name suggests. I updated the tests to conform to this.

The first pass through all the files in doInitialize is also wasted effort tbh and takes up memory. This moves FileRecordReader to iterate over a set of iterators. This only affects subclasses that access the internal iterator directly. All subclasses that are in any of the tests have been updated accordingly. 

## How was this patch tested?
existing maven tests

(My apologies if my first pull request here doesn't meet the standards)