### PR TITLE
Add transforms, etc., from recent POC

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
@@ -38,7 +38,7 @@ public class TransformProcessRecordReader implements RecordReader {
      */
     @Override
     public void initialize(InputSplit split) throws IOException, InterruptedException {
-
+        recordReader.initialize(split);
     }
 
     /**
@@ -51,7 +51,7 @@ public class TransformProcessRecordReader implements RecordReader {
      */
     @Override
     public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
-
+        recordReader.initialize(conf, split);
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/transform/Transform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/Transform.java
@@ -111,7 +111,12 @@ import java.util.List;
                 @JsonSubTypes.Type(value = NDArrayColumnsMathOpTransform.class, name = "NDArrayColumnsMathOpTransform"),
                 @JsonSubTypes.Type(value = NDArrayDistanceTransform.class, name = "NDArrayDistanceTransform"),
                 @JsonSubTypes.Type(value = NDArrayMathFunctionTransform.class, name = "NDArrayMathFunctionTransform"),
-                @JsonSubTypes.Type(value = NDArrayScalarOpTransform.class, name = "NDArrayScalarOpTransform")
+                @JsonSubTypes.Type(value = NDArrayScalarOpTransform.class, name = "NDArrayScalarOpTransform"),
+                @JsonSubTypes.Type(value = ChangeCaseStringTransform.class, name = "ChangeCaseStringTransform"),
+                @JsonSubTypes.Type(value = ConcatenateStringColumns.class, name = "ConcatenateStringColumns"),
+                @JsonSubTypes.Type(value = StringListToCountsNDArrayTransform.class, name = "StringListToCountsNDArrayTransform"),
+                @JsonSubTypes.Type(value = StringListToIndicesNDArrayTransform.class, name = "StringListToIndicesNDArrayTransform"),
+                @JsonSubTypes.Type(value = ConcatenateStringColumns.class, name = "ConcatenateStringColumns"),
 })
 public interface Transform extends Serializable, ColumnOp {
 

--- a/datavec-api/src/main/java/org/datavec/api/transform/Transform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/Transform.java
@@ -116,7 +116,6 @@ import java.util.List;
                 @JsonSubTypes.Type(value = ConcatenateStringColumns.class, name = "ConcatenateStringColumns"),
                 @JsonSubTypes.Type(value = StringListToCountsNDArrayTransform.class, name = "StringListToCountsNDArrayTransform"),
                 @JsonSubTypes.Type(value = StringListToIndicesNDArrayTransform.class, name = "StringListToIndicesNDArrayTransform"),
-                @JsonSubTypes.Type(value = ConcatenateStringColumns.class, name = "ConcatenateStringColumns"),
 })
 public interface Transform extends Serializable, ColumnOp {
 

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/ChangeCaseStringTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/ChangeCaseStringTransform.java
@@ -1,0 +1,53 @@
+package org.datavec.api.transform.transform.string;
+
+import org.datavec.api.writable.Text;
+import org.datavec.api.writable.Writable;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+/**
+ * Change case (to, e.g, all lower case) of String column.
+ *
+ * @author dave@skymind.io
+ */
+public class ChangeCaseStringTransform extends BaseStringTransform {
+    public enum CaseType {
+        LOWER, UPPER
+    }
+
+    private final CaseType caseType;
+
+    public ChangeCaseStringTransform(String column) {
+        super(column);
+        this.caseType = CaseType.LOWER; // default is all lower case
+    }
+
+    public ChangeCaseStringTransform(@JsonProperty("column") String column,
+                                     @JsonProperty("caseType") CaseType caseType) {
+        super(column);
+        this.caseType = caseType;
+    }
+
+    private String mapHelper(String input) {
+        String result;
+        switch (caseType) {
+            case UPPER:
+                result = input.toUpperCase();
+                break;
+            case LOWER:
+            default:
+                result = input.toLowerCase();
+                break;
+        }
+        return result;
+    }
+
+    @Override
+    public Text map(Writable writable) {
+        return new Text(mapHelper(writable.toString()));
+    }
+
+    @Override
+    public Object map(Object input) {
+        return mapHelper(input.toString());
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/ConcatenateStringColumns.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/ConcatenateStringColumns.java
@@ -1,0 +1,198 @@
+package org.datavec.api.transform.transform.string;
+
+import org.datavec.api.transform.ColumnOp;
+import org.datavec.api.transform.ColumnType;
+import org.datavec.api.transform.metadata.ColumnMetaData;
+import org.datavec.api.transform.schema.Schema;
+import org.datavec.api.transform.transform.BaseTransform;
+import org.datavec.api.writable.Text;
+import org.datavec.api.writable.Writable;
+import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Concatenate values of one or more String columns into
+ * a new String column. Retains the constituent String
+ * columns so user must remove those manually, if desired.
+ *
+ * TODO: use new String Reduce functionality in DataVec?
+ *
+ * @author dave@skymind.io
+ */
+@JsonIgnoreProperties({"inputSchema"})
+public class ConcatenateStringColumns extends BaseTransform implements ColumnOp {
+
+    private final String newColumnName;
+    private final String delimiter;
+    private final List<String> columnsToConcatenate;
+    private Schema inputSchema;
+
+    /**
+     * @param columnsToConcatenate A partial or complete order of the columns in the output
+     */
+    public ConcatenateStringColumns(String newColumnName, String delimiter, String... columnsToConcatenate) {
+        this(newColumnName, delimiter, Arrays.asList(columnsToConcatenate));
+    }
+
+    /**
+     * @param columnsToConcatenate A partial or complete order of the columns in the output
+     */
+    public ConcatenateStringColumns(@JsonProperty("newColumnName") String newColumnName,
+                                    @JsonProperty("delimiter") String delimiter,
+                                    @JsonProperty("columnsToConcatenate") List<String> columnsToConcatenate) {
+        this.newColumnName = newColumnName;
+        this.delimiter = delimiter;
+        this.columnsToConcatenate = columnsToConcatenate;
+    }
+
+    @Override
+    public Schema transform(Schema inputSchema) {
+        for (String s : columnsToConcatenate) {
+            if (!inputSchema.hasColumn(s)) {
+                throw new IllegalStateException("Input schema does not contain column with name \"" + s + "\"");
+            }
+        }
+
+        List<ColumnMetaData> outMeta = new ArrayList<>();
+        outMeta.addAll(inputSchema.getColumnMetaData());
+
+        ColumnMetaData newColMeta = ColumnType.String.newColumnMetaData(newColumnName);
+        outMeta.add(newColMeta);
+        return inputSchema.newSchema(outMeta);
+    }
+
+    @Override
+    public void setInputSchema(Schema inputSchema) {
+        for (String s : columnsToConcatenate) {
+            if (!inputSchema.hasColumn(s)) {
+                throw new IllegalStateException("Input schema does not contain column with name \"" + s + "\"");
+            }
+        }
+        this.inputSchema = inputSchema;
+    }
+
+    @Override
+    public Schema getInputSchema() {
+        return inputSchema;
+    }
+
+    @Override
+    public List<Writable> map(List<Writable> writables) {
+        StringBuilder newColumnText = new StringBuilder();
+        List<Writable> out = new ArrayList<>(writables);
+        int i = 0;
+        for (String columnName : columnsToConcatenate) {
+            if (i++ > 0)
+                newColumnText.append(delimiter);
+            int columnIdx = inputSchema.getIndexOfColumn(columnName);
+            newColumnText.append(writables.get(columnIdx));
+        }
+        out.add(new Text(newColumnText.toString()));
+        return out;
+    }
+
+    @Override
+    public List<List<Writable>> mapSequence(List<List<Writable>> sequence) {
+        List<List<Writable>> out = new ArrayList<>();
+        for (List<Writable> step : sequence) {
+            out.add(map(step));
+        }
+        return out;
+    }
+
+    /**
+     * Transform an object
+     * in to another object
+     *
+     * @param input the record to transform
+     * @return the transformed writable
+     */
+    @Override
+    public Object map(Object input) {
+        throw new UnsupportedOperationException(
+                "Unable to map. Please treat this as a special operation. This should be handled by your implementation.");
+
+    }
+
+    /**
+     * Transform a sequence
+     *
+     * @param sequence
+     */
+    @Override
+    public Object mapSequence(Object sequence) {
+        throw new UnsupportedOperationException(
+                "Unable to map. Please treat this as a special operation. This should be handled by your implementation.");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ConcatenateStringColumns o2 = (ConcatenateStringColumns) o;
+        return delimiter.equals(o2.delimiter) && columnsToConcatenate.equals(o2.columnsToConcatenate);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = delimiter.hashCode();
+        result = 31 * result + columnsToConcatenate.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ConcatenateStringColumns(delimiters=" + delimiter + " columnsToConcatenate=" + columnsToConcatenate + ")";
+
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        return newColumnName;
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return new String[]{ newColumnName };
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return columnsToConcatenate.toArray(new String[getInputSchema().getColumnNames().size()]);
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnsToConcatenate.get(0);
+    }}

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToCountsNDArrayTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToCountsNDArrayTransform.java
@@ -1,0 +1,230 @@
+package org.datavec.api.transform.transform.string;
+
+import lombok.EqualsAndHashCode;
+import org.apache.commons.io.FileUtils;
+import org.datavec.api.transform.ColumnType;
+import org.datavec.api.transform.metadata.ColumnMetaData;
+import org.datavec.api.transform.metadata.NDArrayMetaData;
+import org.datavec.api.transform.schema.Schema;
+import org.datavec.api.transform.transform.BaseTransform;
+import org.datavec.api.writable.NDArrayWritable;
+import org.datavec.api.writable.Writable;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Converts String column into a bag-of-words (BOW) represented
+ * as an NDArray of "counts."
+ *
+ * @author dave@skymind.io
+ */
+@JsonIgnoreProperties({"inputSchema", "map", "columnIdx"})
+@EqualsAndHashCode(callSuper = false, exclude = {"columnIdx"})
+public class StringListToCountsNDArrayTransform extends BaseTransform {
+    protected final String columnName;
+    protected final List<String> vocabulary;
+    protected final String delimiter;
+    protected final boolean binary;
+    protected final boolean ignoreUnknown;
+
+    protected final Map<String, Integer> map;
+
+    protected int columnIdx = -1;
+
+    /**
+     * @param columnName     The name of the column to convert
+     * @param vocabulary     The possible tokens that may be present.
+     * @param delimiter      The delimiter for the Strings to convert
+     * @param ignoreUnknown  Whether to ignore unknown tokens
+     */
+    public StringListToCountsNDArrayTransform(@JsonProperty("columnName") String columnName,
+                                              @JsonProperty("vocabulary") List<String> vocabulary,
+                                              @JsonProperty("delimiter") String delimiter,
+                                              @JsonProperty("binary") boolean binary,
+                                              @JsonProperty("ignoreUnknown") boolean ignoreUnknown) {
+        this.columnName = columnName;
+        this.vocabulary = vocabulary;
+        this.delimiter = delimiter;
+        this.binary = binary;
+        this.ignoreUnknown = ignoreUnknown;
+
+        map = new HashMap<>();
+        for (int i = 0; i < vocabulary.size(); i++) {
+            map.put(vocabulary.get(i), i);
+        }
+    }
+
+    public static List<String> readVocabFromFile(String path) throws IOException {
+        return FileUtils.readLines(new File(path), "utf-8");
+    }
+
+    @Override
+    public Schema transform(Schema inputSchema) {
+
+        int colIdx = inputSchema.getIndexOfColumn(columnName);
+
+        List<ColumnMetaData> oldMeta = inputSchema.getColumnMetaData();
+        List<ColumnMetaData> newMeta = new ArrayList<>();
+        List<String> oldNames = inputSchema.getColumnNames();
+
+        Iterator<ColumnMetaData> typesIter = oldMeta.iterator();
+        Iterator<String> namesIter = oldNames.iterator();
+
+        int i = 0;
+        while (typesIter.hasNext()) {
+            ColumnMetaData t = typesIter.next();
+            String name = namesIter.next();
+            if (i++ == colIdx) {
+                //Replace String column with a set of binary/integer columns
+                if (t.getColumnType() != ColumnType.String)
+                    throw new IllegalStateException("Cannot convert non-string type");
+
+                String columnName = this.columnName + "[BOW]";
+                ColumnMetaData meta = new NDArrayMetaData(columnName, new int[]{vocabulary.size()});
+                newMeta.add(meta);
+            } else {
+                newMeta.add(t);
+            }
+        }
+
+        return inputSchema.newSchema(newMeta);
+
+    }
+
+    @Override
+    public void setInputSchema(Schema inputSchema) {
+        this.inputSchema = inputSchema;
+        this.columnIdx = inputSchema.getIndexOfColumn(columnName);
+    }
+
+    @Override
+    public String toString() {
+        return "StringListToCountsTransform(columnName=" + columnName
+                + ",vocabularySize=" + vocabulary.size() + ",delimiter=\"" + delimiter + "\")";
+    }
+
+    protected Collection<Integer> getIndices(String text) {
+        Collection<Integer> indices;
+        if (binary)
+            indices = new HashSet<>();
+        else
+            indices = new ArrayList<>();
+        if (text != null && !text.isEmpty()) {
+            String[] split = text.split(delimiter);
+            for (String s : split) {
+                Integer idx = map.get(s);
+                if (idx == null && !ignoreUnknown)
+                    throw new IllegalStateException("Encountered unknown String: \"" + s + "\"");
+                else if (idx != null)
+                    indices.add(idx);
+            }
+        }
+        return indices;
+    }
+
+    protected INDArray makeBOWNDArray(Collection<Integer> indices) {
+        INDArray counts = Nd4j.zeros(vocabulary.size());
+        for (Integer idx : indices)
+            counts.putScalar(idx, counts.getDouble(idx) + 1);
+        Nd4j.getExecutioner().commit();
+        return counts;
+    }
+
+    @Override
+    public List<Writable> map(List<Writable> writables) {
+        if (writables.size() != inputSchema.numColumns()) {
+            throw new IllegalStateException("Cannot execute transform: input writables list length (" + writables.size()
+                    + ") does not " + "match expected number of elements (schema: " + inputSchema.numColumns()
+                    + "). Transform = " + toString());
+        }
+        int n = writables.size();
+        List<Writable> out = new ArrayList<>(n);
+
+        int i = 0;
+        for (Writable w : writables) {
+            if (i++ == columnIdx) {
+                String text = w.toString();
+                Collection<Integer> indices = getIndices(text);
+                INDArray counts = makeBOWNDArray(indices);
+                out.add(new NDArrayWritable(counts));
+            } else {
+                //No change to this column
+                out.add(w);
+            }
+        }
+
+        return out;
+    }
+
+    /**
+     * Transform an object
+     * in to another object
+     *
+     * @param input the record to transform
+     * @return the transformed writable
+     */
+    @Override
+    public Object map(Object input) {
+        return null;
+    }
+
+    /**
+     * Transform a sequence
+     *
+     * @param sequence
+     */
+    @Override
+    public Object mapSequence(Object sequence) {
+        return null;
+    }
+
+    /**
+     * The output column name
+     * after the operation has been applied
+     *
+     * @return the output column name
+     */
+    @Override
+    public String outputColumnName() {
+        throw new UnsupportedOperationException("New column names is always more than 1 in length");
+    }
+
+    /**
+     * The output column names
+     * This will often be the same as the input
+     *
+     * @return the output column names
+     */
+    @Override
+    public String[] outputColumnNames() {
+        return vocabulary.toArray(new String[vocabulary.size()]);
+    }
+
+    /**
+     * Returns column names
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String[] columnNames() {
+        return new String[] {columnName()};
+    }
+
+    /**
+     * Returns a singular column name
+     * this op is meant to run on
+     *
+     * @return
+     */
+    @Override
+    public String columnName() {
+        return columnName();
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToCountsNDArrayTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToCountsNDArrayTransform.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * Converts String column into a bag-of-words (BOW) represented
- * as an NDArray of "counts."
+ * Converts String column into a bag-of-words (BOW) represented as an NDArray of "counts."<br>
+ * Note that the original column is removed in the process
  *
  * @author dave@skymind.io
  */
@@ -28,6 +28,7 @@ import java.util.*;
 @EqualsAndHashCode(callSuper = false, exclude = {"columnIdx"})
 public class StringListToCountsNDArrayTransform extends BaseTransform {
     protected final String columnName;
+    protected final String newColumnName;
     protected final List<String> vocabulary;
     protected final String delimiter;
     protected final boolean binary;
@@ -43,12 +44,25 @@ public class StringListToCountsNDArrayTransform extends BaseTransform {
      * @param delimiter      The delimiter for the Strings to convert
      * @param ignoreUnknown  Whether to ignore unknown tokens
      */
+    public StringListToCountsNDArrayTransform(String columnName, List<String> vocabulary, String delimiter,
+                                              boolean binary, boolean ignoreUnknown) {
+        this(columnName, columnName+"[BOW]", vocabulary, delimiter, binary, ignoreUnknown);
+    }
+
+    /**
+     * @param columnName     The name of the column to convert
+     * @param vocabulary     The possible tokens that may be present.
+     * @param delimiter      The delimiter for the Strings to convert
+     * @param ignoreUnknown  Whether to ignore unknown tokens
+     */
     public StringListToCountsNDArrayTransform(@JsonProperty("columnName") String columnName,
+                                              @JsonProperty("newColumnName") String newColumnName,
                                               @JsonProperty("vocabulary") List<String> vocabulary,
                                               @JsonProperty("delimiter") String delimiter,
                                               @JsonProperty("binary") boolean binary,
                                               @JsonProperty("ignoreUnknown") boolean ignoreUnknown) {
         this.columnName = columnName;
+        this.newColumnName = newColumnName;
         this.vocabulary = vocabulary;
         this.delimiter = delimiter;
         this.binary = binary;
@@ -85,8 +99,7 @@ public class StringListToCountsNDArrayTransform extends BaseTransform {
                 if (t.getColumnType() != ColumnType.String)
                     throw new IllegalStateException("Cannot convert non-string type");
 
-                String columnName = this.columnName + "[BOW]";
-                ColumnMetaData meta = new NDArrayMetaData(columnName, new int[]{vocabulary.size()});
+                ColumnMetaData meta = new NDArrayMetaData(newColumnName, new int[]{vocabulary.size()});
                 newMeta.add(meta);
             } else {
                 newMeta.add(t);

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToIndicesNDArrayTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToIndicesNDArrayTransform.java
@@ -1,0 +1,45 @@
+package org.datavec.api.transform.transform.string;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Converts String column into a sparse bag-of-words (BOW)
+ * represented as an NDArray of indices. Appropriate for
+ * embeddings or as efficient storage before being expanded
+ * into a dense array.
+ *
+ * @author dave@skymind.io
+ */
+public class StringListToIndicesNDArrayTransform extends StringListToCountsNDArrayTransform {
+    /**
+     * @param columnName     The name of the column to convert
+     * @param vocabulary     The possible tokens that may be present.
+     * @param delimiter      The delimiter for the Strings to convert
+     * @param ignoreUnknown  Whether to ignore unknown tokens
+     */
+    public StringListToIndicesNDArrayTransform(@JsonProperty("columnName") String columnName,
+                                               @JsonProperty("vocabulary") List<String> vocabulary,
+                                               @JsonProperty("delimiter") String delimiter,
+                                               @JsonProperty("binary") boolean binary,
+                                               @JsonProperty("ignoreUnknown") boolean ignoreUnknown) {
+        super(columnName, vocabulary, delimiter, binary, ignoreUnknown);
+    }
+
+    @Override
+    protected INDArray makeBOWNDArray(Collection<Integer> indices) {
+        INDArray counts = Nd4j.zeros(indices.size());
+        List<Integer> indicesSorted = new ArrayList<>(indices);
+        Collections.sort(indicesSorted);
+        for (int i = 0; i < indicesSorted.size(); i++)
+            counts.putScalar(i, indicesSorted.get(i));
+        Nd4j.getExecutioner().commit();
+        return counts;
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToIndicesNDArrayTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/StringListToIndicesNDArrayTransform.java
@@ -24,12 +24,18 @@ public class StringListToIndicesNDArrayTransform extends StringListToCountsNDArr
      * @param delimiter      The delimiter for the Strings to convert
      * @param ignoreUnknown  Whether to ignore unknown tokens
      */
+    public StringListToIndicesNDArrayTransform(String columnName, List<String> vocabulary, String delimiter,
+                                               boolean binary, boolean ignoreUnknown) {
+        super(columnName, vocabulary, delimiter, binary, ignoreUnknown);
+    }
+
     public StringListToIndicesNDArrayTransform(@JsonProperty("columnName") String columnName,
+                                               @JsonProperty("newColumnName") String newColumnName,
                                                @JsonProperty("vocabulary") List<String> vocabulary,
                                                @JsonProperty("delimiter") String delimiter,
                                                @JsonProperty("binary") boolean binary,
                                                @JsonProperty("ignoreUnknown") boolean ignoreUnknown) {
-        super(columnName, vocabulary, delimiter, binary, ignoreUnknown);
+        super(columnName, newColumnName, vocabulary, delimiter, binary, ignoreUnknown);
     }
 
     @Override

--- a/datavec-api/src/test/java/org/datavec/api/transform/transform/TestTransforms.java
+++ b/datavec-api/src/test/java/org/datavec/api/transform/transform/TestTransforms.java
@@ -250,6 +250,88 @@ public class TestTransforms {
     }
 
     @Test
+    public void testConcatenateStringColumnsTransform() throws Exception {
+        final String DELIMITER = " ";
+        final String NEW_COLUMN = "NewColumn";
+        final List<String> CONCAT_COLUMNS = Arrays.asList("ConcatenatedColumn1", "ConcatenatedColumn2", "ConcatenatedColumn3");
+        final List<String> ALL_COLUMNS = Arrays.asList("ConcatenatedColumn1", "OtherColumn4", "ConcatenatedColumn2",
+                "OtherColumn5", "ConcatenatedColumn3", "OtherColumn6");
+        final List<Text> COLUMN_VALUES = Arrays.asList(new Text("string1"), new Text("other4"),
+                new Text("string2"), new Text("other5"),
+                new Text("string3"), new Text("other6"));
+        final String NEW_COLUMN_VALUE = "string1 string2 string3";
+
+        Transform transform = new ConcatenateStringColumns(NEW_COLUMN, DELIMITER, CONCAT_COLUMNS);
+        String[] allColumns = ALL_COLUMNS.toArray(new String[ALL_COLUMNS.size()]);
+        Schema schema = new Schema.Builder().addColumnsString(allColumns).build();
+
+        List<String> outputColumns = new ArrayList<>(ALL_COLUMNS);
+        outputColumns.add(NEW_COLUMN);
+        Schema newSchema = transform.transform(schema);
+        Assert.assertEquals(outputColumns, newSchema.getColumnNames());
+
+        List<Writable> input = new ArrayList<>();
+        for (Writable value : COLUMN_VALUES)
+            input.add(value);
+
+        transform.setInputSchema(schema);
+        List<Writable> transformed = transform.map(input);
+        Assert.assertEquals(NEW_COLUMN_VALUE, transformed.get(transformed.size() - 1).toString());
+
+        List<Text> outputColumnValues = new ArrayList<>(COLUMN_VALUES);
+        outputColumnValues.add(new Text(NEW_COLUMN_VALUE));
+        Assert.assertEquals(outputColumnValues, transformed);
+
+        ObjectMapper om = TestUtil.initMapper(new JsonFactory());
+        String s = om.writeValueAsString(transform);
+        Transform transform2 = om.readValue(s, ConcatenateStringColumns.class);
+        Assert.assertEquals(transform, transform2);
+    }
+
+    @Test
+    public void testChangeCaseStringTransform() throws Exception {
+        final String STRING_COLUMN = "StringColumn";
+        final List<String> ALL_COLUMNS = Arrays.asList(STRING_COLUMN, "OtherColumn");
+        final String TEXT_MIXED_CASE = "UPPER lower MiXeD";
+        final String TEXT_UPPER_CASE = TEXT_MIXED_CASE.toUpperCase();
+        final String TEXT_LOWER_CASE = TEXT_MIXED_CASE.toLowerCase();
+
+        Transform transform = new ChangeCaseStringTransform(STRING_COLUMN);
+        String[] allColumns = ALL_COLUMNS.toArray(new String[ALL_COLUMNS.size()]);
+        Schema schema = new Schema.Builder().addColumnsString(allColumns).build();
+        transform.setInputSchema(schema);
+        Schema newSchema = transform.transform(schema);
+        List<String> outputColumns = new ArrayList<>(ALL_COLUMNS);
+        Assert.assertEquals(outputColumns, newSchema.getColumnNames());
+
+        transform = new ChangeCaseStringTransform(STRING_COLUMN, ChangeCaseStringTransform.CaseType.LOWER);
+        transform.setInputSchema(schema);
+        List<Writable> input = new ArrayList<>();
+        input.add(new Text(TEXT_MIXED_CASE));
+        input.add(new Text(TEXT_MIXED_CASE));
+        List<Writable> output = new ArrayList<>();
+        output.add(new Text(TEXT_LOWER_CASE));
+        output.add(new Text(TEXT_MIXED_CASE));
+        List<Writable> transformed = transform.map(input);
+        Assert.assertEquals(transformed.get(0).toString(), TEXT_LOWER_CASE);
+        Assert.assertEquals(transformed, output);
+
+        transform = new ChangeCaseStringTransform(STRING_COLUMN, ChangeCaseStringTransform.CaseType.UPPER);
+        transform.setInputSchema(schema);
+        output.clear();
+        output.add(new Text(TEXT_UPPER_CASE));
+        output.add(new Text(TEXT_MIXED_CASE));
+        transformed = transform.map(input);
+        Assert.assertEquals(transformed.get(0).toString(), TEXT_UPPER_CASE);
+        Assert.assertEquals(transformed, output);
+
+        ObjectMapper om = TestUtil.initMapper(new JsonFactory());
+        String s = om.writeValueAsString(transform);
+        Transform transform2 = om.readValue(s, ChangeCaseStringTransform.class);
+        Assert.assertEquals(transform, transform2);
+    }
+
+    @Test
     public void testRemoveColumnsTransform() {
         Schema schema = new Schema.Builder().addColumnDouble("first").addColumnString("second")
                         .addColumnInteger("third").addColumnLong("fourth").build();

--- a/datavec-api/src/test/java/org/datavec/api/transform/transform/TestUtil.java
+++ b/datavec-api/src/test/java/org/datavec/api/transform/transform/TestUtil.java
@@ -1,0 +1,36 @@
+package org.datavec.api.transform.transform;
+
+import org.nd4j.shade.jackson.annotation.JsonAutoDetect;
+import org.nd4j.shade.jackson.annotation.PropertyAccessor;
+import org.nd4j.shade.jackson.core.JsonFactory;
+import org.nd4j.shade.jackson.databind.DeserializationFeature;
+import org.nd4j.shade.jackson.databind.ObjectMapper;
+import org.nd4j.shade.jackson.databind.SerializationFeature;
+import org.nd4j.shade.jackson.datatype.joda.JodaModule;
+
+/**
+ * Some utilities for unit tests.
+ *
+ * @author dave@skymind.io
+ */
+public class TestUtil {
+
+    /**
+     * Clone of initMapper used for serialization and deserialization
+     * of TransformProcess class, to support unit testing of
+     * serialization and deserializtion of individual transforms.
+     *
+     * @param factory   JsonFactory
+     * @return          ObjectMapper for serde of transforms
+     */
+    public static ObjectMapper initMapper(JsonFactory factory) {
+        ObjectMapper om = new ObjectMapper(new JsonFactory());
+        om.registerModule(new JodaModule());
+        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        om.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        om.enable(SerializationFeature.INDENT_OUTPUT);
+        om.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        om.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        return om;
+    }
+}

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/misc/WritablesToNDArrayFunction.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/misc/WritablesToNDArrayFunction.java
@@ -1,0 +1,55 @@
+package org.datavec.spark.transform.misc;
+
+import org.apache.spark.api.java.function.Function;
+import org.datavec.api.writable.NDArrayWritable;
+import org.datavec.api.writable.Writable;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Function for converting lists of Writables to a single
+ * NDArray row vector. Necessary for creating and saving a
+ * dense matrix representation of raw data.
+ *
+ * @author dave@skymind.io
+ */
+public class WritablesToNDArrayFunction implements Function<List<Writable>, INDArray> {
+
+    @Override
+    public INDArray call(List<Writable> c) throws Exception {
+        int length = 0;
+        for (Writable w : c) {
+            if (w instanceof NDArrayWritable) {
+                INDArray a = ((NDArrayWritable)w).get();
+                if (a.isRowVector()) {
+                    length += a.columns();
+                } else {
+                    throw new UnsupportedOperationException("NDArrayWritable is not a row vector."
+                            + " Can only concat row vectors with other writables. Shape: "
+                            + Arrays.toString(a.shape()));
+                }
+            } else {
+                length = 1;
+            }
+        }
+
+        INDArray arr = Nd4j.zeros(length);
+        int idx = 0;
+        for (Writable w : c) {
+            if (w instanceof NDArrayWritable) {
+                INDArray subArr = ((NDArrayWritable)w).get();
+                int subLength = subArr.columns();
+                arr.get(NDArrayIndex.interval(idx, idx + subLength)).assign(subArr);
+                idx += subLength;
+            } else {
+                arr.putScalar(idx++, w.toDouble());
+            }
+        }
+
+        return arr;
+    }
+}


### PR DESCRIPTION
**NOTE: Replaces https://github.com/deeplearning4j/DataVec/pull/336. Branched from master instead of @alexdblack's [branch](https://github.com/deeplearning4j/DataVec/tree/ab_333_texttoseq).**

## What changes were proposed in this pull request?

Adding some transforms:

- ChangeCaseStringTransform: change case of string column
- ConcatenateStringColumns: concatenate multiple string columns into one
- StringListToCountsNDArrayTransform: string column to dense BOW NDArray
- StringListToIndicesNDArrayTransform: string column to sparse BOW NDArray (i.e., list of indices)

and one Spark function:

- WritablesToNDArrayFunction: convert a list of writables to an NDArray

Also, updated TransformProcessRecordReader to initialize its member RecordReader rather than force user to do it manually.

## How was this patch tested?

Added unit tests ChangeCaseStringTransform and ConcatenateStringColumns to TestTransforms unit test class. Haven't added unit tests for StringListTo*NDArray transforms, WritablesToNDArrayFunction, or for TPRR update.