### PR TITLE
make failures of buildmultiplescalaversions.sh more informative

### DIFF
--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,22 +1,44 @@
 #! /bin/bash
 BASEDIR=$(dirname $(readlink -f "$0"))
 
+function echoError() {
+    (>&2 echo $1)
+}
+
+function sparkError() {
+    echoError "Changing Spark major version to 2 in the build did not change the state of your working copy, is Spark 1.x still the default ?"
+    exit 2
+}
+
+function scalaError() {
+    echoError "Changing Scala major version to 2.10 in the build did not change the state of your working copy, is Scala 2.11 still the default ?"
+    exit 2
+}
+
 function whatchanged() {
     cd $BASEDIR
     for i in $(git status -s --porcelain -- $(find ./ -mindepth 2 -name pom.xml)|awk '{print $2}'); do
-	echo $(dirname $i)
-	cd $BASEDIR
+        echo $(dirname $i)
+        cd $BASEDIR
     done
 }
 
 set -eu
-./change-scala-versions.sh 2.11 # should be idempotent, this is the default
-./change-spark-versions.sh 1
+./change-scala-versions.sh 2.11
+./change-spark-versions.sh 1 # should be idempotent, this is the default
 mvn "$@"
 ./change-spark-versions.sh 2
-mvn -Dspark.major.version=2 -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
+if [ -z $(whatchanged)]; then
+    sparkError;
+else
+    mvn -Dspark.major.version=2 -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
+fi
 ./change-scala-versions.sh 2.10
 ./change-spark-versions.sh 1
-mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
+if [ -z $(whatchanged)]; then
+    scalaError;
+else
+    mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
+fi
 ./change-scala-versions.sh 2.11 # back to the default
 ./change-spark-versions.sh 1


### PR DESCRIPTION
Avoids confusion when the Scala/Spark version default changes in the repo, but not in the script, or vice versa.