### PR TITLE
Add NDArrayToWritablesFunction for Spark ETL

### DIFF
--- a/datavec-spark/src/main/java/org/datavec/spark/transform/misc/NDArrayToWritablesFunction.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/misc/NDArrayToWritablesFunction.java
@@ -1,0 +1,56 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.spark.transform.misc;
+
+import lombok.AllArgsConstructor;
+import org.apache.spark.api.java.function.Function;
+import org.datavec.api.writable.DoubleWritable;
+import org.datavec.api.writable.NDArrayWritable;
+import org.datavec.api.writable.Writable;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convert an NDArray to a List<Writable> using a DataVec record reader
+ *
+ * @author dave@skymind.io
+ */
+@AllArgsConstructor
+public class NDArrayToWritablesFunction implements Function<INDArray, List<Writable>> {
+    private boolean useNdarrayWritable = false;
+
+    public NDArrayToWritablesFunction() {
+        useNdarrayWritable = false;
+    }
+
+    @Override
+    public List<Writable> call(INDArray arr) throws Exception {
+        if (arr.rows() != 1)
+            throw new UnsupportedOperationException("Only NDArray row vectors can be converted to list"
+                                                + " of Writables (found " + arr.rows() + " rows)");
+        List<Writable> record = new ArrayList<>();
+        if (useNdarrayWritable) {
+            record.add(new NDArrayWritable(arr));
+        } else {
+            for (int i = 0; i < arr.columns(); i++)
+                record.add(new DoubleWritable(arr.getDouble(i)));
+        }
+        return record;
+    }
+}

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/misc/NDArrayToWritablesFunction.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/misc/NDArrayToWritablesFunction.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Convert an NDArray to a List<Writable> using a DataVec record reader
+ * Function for converting NDArrays to lists of writables.
  *
  * @author dave@skymind.io
  */

--- a/datavec-spark/src/test/java/org/datavec/spark/functions/TestNDArrayToWritablesFunction.java
+++ b/datavec-spark/src/test/java/org/datavec/spark/functions/TestNDArrayToWritablesFunction.java
@@ -1,0 +1,57 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.spark.functions;
+
+import org.datavec.api.writable.DoubleWritable;
+import org.datavec.api.writable.NDArrayWritable;
+import org.datavec.api.writable.Writable;
+import org.datavec.spark.transform.misc.NDArrayToWritablesFunction;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for NDArrayToWritables function
+ *
+ * @author dave@skymind.io
+ */
+public class TestNDArrayToWritablesFunction {
+
+    @Test
+    public void testNDArrayToWritablesScalars() throws Exception {
+        INDArray arr = Nd4j.arange(5);
+        List<Writable> expected = new ArrayList<>();
+        for (int i = 0; i < 5; i++)
+            expected.add(new DoubleWritable(i));
+        List<Writable> actual = new NDArrayToWritablesFunction().call(arr);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testNDArrayToWritablesArray() throws Exception {
+        INDArray arr = Nd4j.arange(5);
+        List<Writable> expected = Arrays.asList((Writable) new NDArrayWritable(arr));
+        List<Writable> actual = new NDArrayToWritablesFunction(true).call(arr);
+        assertEquals(expected, actual);
+    }
+}

--- a/datavec-spark/src/test/java/org/datavec/spark/functions/TestNDArrayToWritablesFunction.java
+++ b/datavec-spark/src/test/java/org/datavec/spark/functions/TestNDArrayToWritablesFunction.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Unit tests for NDArrayToWritables function
+ * Unit tests for NDArrayToWritablesFunction.
  *
  * @author dave@skymind.io
  */


### PR DESCRIPTION
Add spark function for converting NDArray to list of Writables. Constructor takes a boolean to indicate whether to convert NDArray to list of scalar Writables or singleton list containing one NDArrayWritable.

## What changes were proposed in this pull request?

See above.

## How was this patch tested?

Adds unit tests for both cases.

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
