### PR TITLE
Inferred schema, CSV parser, and more transforms.

### DIFF
--- a/datavec-api/pom.xml
+++ b/datavec-api/pom.xml
@@ -128,6 +128,13 @@
             <version>${nd4j.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- csv parser, same dep used by spark -->
+        <dependency>
+            <groupId>net.sf.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>2.3</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/datavec-api/src/main/java/org/datavec/api/conf/Configuration.java
+++ b/datavec-api/src/main/java/org/datavec/api/conf/Configuration.java
@@ -389,6 +389,36 @@ public class Configuration implements Iterable<Map.Entry<String, String>>, Writa
     }
 
     /**
+     * Get the char value of the <code>name</code> property, <code>null</code> if
+     * no such property exists.
+     *
+     * Values are processed for <a href="#VariableExpansion">variable expansion</a>
+     * before being returned.
+     *
+     * @param name the property name.
+     * @return the value of the <code>name</code> property,
+     *         or null if no such property exists.
+     */
+    public char getChar(String name) {
+        return getProps().getProperty(name).charAt(0);
+    }
+
+    /**
+     * Get the char value of the <code>name</code> property, <code>null</code> if
+     * no such property exists.
+     *
+     * Values are processed for <a href="#VariableExpansion">variable expansion</a>
+     * before being returned.
+     *
+     * @param name the property name.
+     * @return the value of the <code>name</code> property,
+     *         or null if no such property exists.
+     */
+    public char getChar(String name, char defaultValue) {
+        return getProps().getProperty(name, String.valueOf(defaultValue)).charAt(0);
+    }
+
+    /**
      * Set the <code>value</code> of the <code>name</code> property.
      *
      * @param name property name.

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVNLinesSequenceRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVNLinesSequenceRecordReader.java
@@ -47,6 +47,7 @@ public class CSVNLinesSequenceRecordReader extends CSVRecordReader implements Se
     public static final String LINES_PER_SEQUENCE = NAME_SPACE + ".nlinespersequence";
 
     private int nLinesPerSequence;
+    private String delimiter;
 
     /**
      * No-arg constructor with the default number of lines per sequence (10)
@@ -59,7 +60,7 @@ public class CSVNLinesSequenceRecordReader extends CSVRecordReader implements Se
      * @param nLinesPerSequence    Number of lines in each sequence, use default delemiter(,) between entries in the same line
      */
     public CSVNLinesSequenceRecordReader(int nLinesPerSequence) {
-        this(nLinesPerSequence, 0, CSVRecordReader.DEFAULT_DELIMITER);
+        this(nLinesPerSequence, 0, String.valueOf(CSVRecordReader.DEFAULT_DELIMITER));
     }
 
     /**
@@ -69,7 +70,8 @@ public class CSVNLinesSequenceRecordReader extends CSVRecordReader implements Se
      * @param delimiter            Delimiter between entries in the same line, for example ","
      */
     public CSVNLinesSequenceRecordReader(int nLinesPerSequence, int skipNumLines, String delimiter) {
-        super(skipNumLines, delimiter);
+        super(skipNumLines);
+        this.delimiter = delimiter;
         this.nLinesPerSequence = nLinesPerSequence;
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -17,7 +17,6 @@
 package org.datavec.api.records.reader.impl.csv;
 
 
-import au.com.bytecode.opencsv.CSVParser;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.Record;
 import org.datavec.api.records.metadata.RecordMetaData;
@@ -30,7 +29,6 @@ import org.datavec.api.writable.Writable;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +48,7 @@ public class CSVRecordReader extends LineRecordReader {
     public final static String DELIMITER = NAME_SPACE + ".delimiter";
     public final static String QUOTE = NAME_SPACE + ".quote";
 
-    private CSVParser csvParser;
+    private SerializableCSVParser csvParser;
 
     /**
      * Skip first n lines
@@ -77,7 +75,7 @@ public class CSVRecordReader extends LineRecordReader {
      */
     public CSVRecordReader(int skipNumLines, char delimiter, char quote) {
         this.skipNumLines = skipNumLines;
-        this.csvParser = new CSVParser(delimiter, quote);
+        this.csvParser = new SerializableCSVParser(delimiter, quote);
     }
 
     public CSVRecordReader() {
@@ -88,7 +86,7 @@ public class CSVRecordReader extends LineRecordReader {
     public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
         super.initialize(conf, split);
         this.skipNumLines = conf.getInt(SKIP_NUM_LINES, this.skipNumLines);
-        this.csvParser = new CSVParser(conf.getChar(DELIMITER, DEFAULT_DELIMITER), conf.getChar(QUOTE, DEFAULT_QUOTE));
+        this.csvParser = new SerializableCSVParser(conf.getChar(DELIMITER, DEFAULT_DELIMITER), conf.getChar(QUOTE, DEFAULT_QUOTE));
     }
 
     private boolean skipLines() {

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -17,6 +17,7 @@
 package org.datavec.api.records.reader.impl.csv;
 
 
+import au.com.bytecode.opencsv.CSVParser;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.Record;
 import org.datavec.api.records.metadata.RecordMetaData;
@@ -29,6 +30,7 @@ import org.datavec.api.writable.Writable;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,18 +42,15 @@ import java.util.NoSuchElementException;
  * @author Adam Gibson
  */
 public class CSVRecordReader extends LineRecordReader {
-    /** A regex delimiter that can parse quotes (string literals) that may have commas in them: http://stackoverflow.com/a/1757107/523744
-     * Note: This adds considerable overhead compared to the default "," delimiter, and should only be used when necessary.
-     * */
-    public final static String QUOTE_HANDLING_DELIMITER = ",(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
     private boolean skippedLines = false;
     protected int skipNumLines = 0;
-    protected String delimiter = DEFAULT_DELIMITER;
-    protected String quote = null;
-    public final static String DEFAULT_DELIMITER = ",";
+    public final static char DEFAULT_DELIMITER = ',';
+    public final static char DEFAULT_QUOTE = '\"';
     public final static String SKIP_NUM_LINES = NAME_SPACE + ".skipnumlines";
     public final static String DELIMITER = NAME_SPACE + ".delimiter";
     public final static String QUOTE = NAME_SPACE + ".quote";
+
+    private CSVParser csvParser;
 
     /**
      * Skip first n lines
@@ -66,8 +65,8 @@ public class CSVRecordReader extends LineRecordReader {
      * @param skipNumLines the number of lines to skip
      * @param delimiter the delimiter
      */
-    public CSVRecordReader(int skipNumLines, String delimiter) {
-        this(skipNumLines, delimiter, null);
+    public CSVRecordReader(int skipNumLines, char delimiter) {
+        this(skipNumLines, delimiter, '\"');
     }
 
     /**
@@ -76,10 +75,9 @@ public class CSVRecordReader extends LineRecordReader {
      * @param delimiter the delimiter
      * @param quote the quote to strip
      */
-    public CSVRecordReader(int skipNumLines, String delimiter, String quote) {
+    public CSVRecordReader(int skipNumLines, char delimiter, char quote) {
         this.skipNumLines = skipNumLines;
-        this.delimiter = delimiter;
-        this.quote = quote;
+        this.csvParser = new CSVParser(delimiter, quote);
     }
 
     public CSVRecordReader() {
@@ -90,8 +88,7 @@ public class CSVRecordReader extends LineRecordReader {
     public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
         super.initialize(conf, split);
         this.skipNumLines = conf.getInt(SKIP_NUM_LINES, this.skipNumLines);
-        this.delimiter = conf.get(DELIMITER, DEFAULT_DELIMITER);
-        this.quote = conf.get(QUOTE, null);
+        this.csvParser = new CSVParser(conf.getChar(DELIMITER, DEFAULT_DELIMITER), conf.getChar(QUOTE, DEFAULT_QUOTE));
     }
 
     private boolean skipLines() {
@@ -122,13 +119,14 @@ public class CSVRecordReader extends LineRecordReader {
     }
 
     protected List<Writable> parseLine(String line) {
-        String[] split = line.split(delimiter, -1);
+        String[] split;
+        try {
+            split = csvParser.parseLine(line);
+        } catch(IOException e) {
+            throw new RuntimeException(e);
+        }
         List<Writable> ret = new ArrayList<>();
         for (String s : split) {
-            if (quote != null && s.startsWith(quote) && s.endsWith(quote)) {
-                int n = quote.length();
-                s = s.substring(n, s.length() - n).replace(quote + quote, quote);
-            }
             ret.add(new Text(s));
         }
         return ret;

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRegexRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRegexRecordReader.java
@@ -33,6 +33,8 @@ public class CSVRegexRecordReader extends CSVRecordReader {
 
     protected String[] regexs = null;
     protected Pattern[] patterns = null;
+    protected String delimiter;
+    protected String quote;
 
     /**
      * Skip lines, use delimiter, strip quotes, and parse each column with a regex
@@ -42,7 +44,9 @@ public class CSVRegexRecordReader extends CSVRecordReader {
      * @param regexs the regexs to parse columns with
      */
     public CSVRegexRecordReader(int skipNumLines, String delimiter, String quote, String[] regexs) {
-        super(skipNumLines, delimiter, quote);
+        super(skipNumLines);
+        this.delimiter = delimiter;
+        this.quote = quote;
         this.regexs = regexs;
         if (regexs != null) {
             patterns = new Pattern[regexs.length];

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/SerializableCSVParser.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/SerializableCSVParser.java
@@ -1,0 +1,29 @@
+package org.datavec.api.records.reader.impl.csv;
+
+import au.com.bytecode.opencsv.CSVParser;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Allows CSVParser to be serialized for spark.
+ */
+public class SerializableCSVParser extends CSVParser implements Serializable {
+
+    public SerializableCSVParser() {
+        super();
+    }
+
+    public SerializableCSVParser(char delimiter) {
+        super(delimiter);
+    }
+
+    public SerializableCSVParser(char delimiter, char quote) {
+        super(delimiter, quote);
+    }
+
+    public SerializableCSVParser(char delimiter, char quote, char escape, boolean strictQuotes, boolean ignoreLeadingWhiteSpace) {
+        super(delimiter, quote, escape, strictQuotes, ignoreLeadingWhiteSpace);
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/TransformProcess.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/TransformProcess.java
@@ -46,6 +46,7 @@ import org.datavec.api.transform.transform.column.*;
 import org.datavec.api.transform.transform.condition.ConditionalCopyValueTransform;
 import org.datavec.api.transform.transform.condition.ConditionalReplaceValueTransform;
 import org.datavec.api.transform.transform.doubletransform.*;
+import org.datavec.api.transform.transform.integer.ConvertToInteger;
 import org.datavec.api.transform.transform.integer.IntegerColumnsMathOpTransform;
 import org.datavec.api.transform.transform.integer.IntegerMathOpTransform;
 import org.datavec.api.transform.transform.integer.IntegerToOneHotTransform;
@@ -851,7 +852,8 @@ public class TransformProcess implements Serializable {
         }
 
         /**
-         * Add a new integer column, where the value for that column (for all records) are identical
+         * Add a new integer column, where th
+         * e value for that column (for all records) are identical
          *
          * @param newColumnName Name of the new column
          * @param value         Value of the new column for all records
@@ -878,6 +880,26 @@ public class TransformProcess implements Serializable {
          */
         public Builder convertToString(String inputColumn) {
             return transform(new ConvertToString(inputColumn));
+        }
+
+
+        /**
+         * Convert the specified column to a double.
+         * @param inputColumn the input column to convert
+         * @return builder pattern
+         */
+        public Builder convertToDouble(String inputColumn) {
+            return transform(new ConvertToDouble(inputColumn));
+        }
+
+
+        /**
+         * Convert the specified column to an integer.
+         * @param inputColumn the input column to convert
+         * @return builder pattern
+         */
+        public Builder convertToInteger(String inputColumn) {
+            return transform(new ConvertToInteger(inputColumn));
         }
 
         /**

--- a/datavec-api/src/main/java/org/datavec/api/transform/schema/InferredSchema.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/schema/InferredSchema.java
@@ -1,0 +1,158 @@
+package org.datavec.api.transform.schema;
+
+import au.com.bytecode.opencsv.CSVParser;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * If passed a CSV file that contains a header and a single row of sample data, it will return
+ * a Schema.
+ *
+ * Only Double, Integer, Long, and String types are supported. If no number type can be inferred,
+ * the field type will become the default type. Note that if your column is actually categorical but
+ * is represented as a number, you will need to do additional transformation. Also, if your sample
+ * field is blank/null, it will also become the default type.
+ *
+ * @author Justin Long (crockpotveggies)
+ */
+@Slf4j
+public class InferredSchema {
+    protected Schema.Builder schemaBuilder;
+    protected String pathToCsv;
+    protected DataType defaultType;
+    protected String quote;
+
+    private CSVParser csvParser = new CSVParser();
+
+    public InferredSchema(String pathToCsv) {
+        this.pathToCsv = pathToCsv;
+        this.defaultType = DataType.valueOf("STRING");
+    }
+
+    public InferredSchema(String pathToCsv, DataType defaultType) {
+        this.pathToCsv = pathToCsv;
+        this.defaultType = defaultType;
+    }
+
+    public InferredSchema(String pathToCsv, DataType defaultType, char delimiter) {
+        this.pathToCsv = pathToCsv;
+        this.defaultType = defaultType;
+        this.csvParser = new CSVParser(delimiter);
+    }
+
+    public InferredSchema(String pathToCsv, DataType defaultType, char delimiter, char quote) {
+        this.pathToCsv = pathToCsv;
+        this.defaultType = defaultType;
+        this.csvParser = new CSVParser(delimiter, quote);
+    }
+
+    public InferredSchema(String pathToCsv, DataType defaultType, char delimiter, char quote, char escape) {
+        this.pathToCsv = pathToCsv;
+        this.defaultType = defaultType;
+        this.csvParser = new CSVParser(delimiter, quote, escape);
+    }
+
+    public Schema build() throws IOException {
+        List<String> headersAndRows = null;
+        this.schemaBuilder = new Schema.Builder();
+
+        try {
+            headersAndRows = FileUtils.readLines(new File(pathToCsv));
+        } catch (IOException e) {
+            log.error("An error occurred while parsing sample CSV for schema", e);
+        }
+        List<String> headers = parseLine(headersAndRows.get(0));
+        List<String> samples = parseLine(headersAndRows.get(1));
+
+        if(headers.size() != samples.size())
+            throw new IllegalStateException("CSV headers length does not match number of sample columns. " +
+                    "Please check that your CSV is valid, or check the delimiter used to parse the CSV.");
+
+        for(int i = 0; i < headers.size(); i++) {
+            inferAndAddType(schemaBuilder, headers.get(i), samples.get(i));
+        }
+        return schemaBuilder.build();
+    }
+
+    private Schema.Builder inferAndAddType(Schema.Builder builder, String header, String sample) {
+        if(isParsableAsDouble(sample)) addOn(builder, header, DataType.DOUBLE);
+        else if(isParsableAsInteger(sample)) addOn(builder, header, DataType.INTEGER);
+        else if(isParsableAsLong(sample)) addOn(builder, header, DataType.LONG);
+        else addOn(builder, header, defaultType);
+
+        return schemaBuilder;
+    }
+
+    private static Schema.Builder addOn(Schema.Builder builder, String columnName, DataType columnType) {
+        switch (columnType) {
+            case DOUBLE:
+                return builder.addColumnDouble(columnName, null, null, false, false); //no nans/inf
+            case INTEGER:
+                return builder.addColumnInteger(columnName);
+            case LONG:
+                return builder.addColumnLong(columnName);
+            case STRING:
+                return builder.addColumnString(columnName);
+            default:
+                throw new IllegalArgumentException("Schema inputs have to be string, integer or double");
+        }
+    }
+
+    private List<String> parseLine(String line) throws IOException {
+        String[] split = csvParser.parseLine(line);
+        ArrayList ret = new ArrayList();
+        String[] var4 = split;
+        int var5 = split.length;
+
+        for(int var6 = 0; var6 < var5; ++var6) {
+            String s = var4[var6];
+            if(this.quote != null && s.startsWith(this.quote) && s.endsWith(this.quote)) {
+                int n = this.quote.length();
+                s = s.substring(n, s.length() - n).replace(this.quote + this.quote, this.quote);
+            }
+            ret.add(s);
+        }
+
+        return ret;
+    }
+
+    private static boolean isParsableAsLong(final String s) {
+        try {
+            Long.valueOf(s);
+            return true;
+        } catch (NumberFormatException numberFormatException) {
+            return false;
+        }
+    }
+
+    private static boolean isParsableAsInteger(final String s) {
+        try {
+            Integer.valueOf(s);
+            return true;
+        } catch (NumberFormatException numberFormatException) {
+            return false;
+        }
+    }
+
+
+    private static boolean isParsableAsDouble(final String s) {
+        try {
+            Double.valueOf(s);
+            return true;
+        } catch (NumberFormatException numberFormatException) {
+            return false;
+        }
+    }
+
+    private enum DataType {
+        STRING,
+        INTEGER,
+        DOUBLE,
+        LONG
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/BaseDoubleTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/BaseDoubleTransform.java
@@ -18,6 +18,7 @@ package org.datavec.api.transform.transform.doubletransform;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.datavec.api.transform.metadata.ColumnMetaData;
 import org.datavec.api.transform.metadata.DoubleMetaData;
 import org.datavec.api.transform.transform.BaseColumnTransform;
@@ -28,6 +29,7 @@ import org.datavec.api.writable.Writable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
+@NoArgsConstructor
 public abstract class BaseDoubleTransform extends BaseColumnTransform {
 
     public BaseDoubleTransform(String column) {

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/ConvertToDouble.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/ConvertToDouble.java
@@ -1,0 +1,43 @@
+package org.datavec.api.transform.transform.doubletransform;
+
+import lombok.NoArgsConstructor;
+import org.datavec.api.transform.transform.integer.BaseIntegerTransform;
+import org.datavec.api.writable.DoubleWritable;
+import org.datavec.api.writable.IntWritable;
+import org.datavec.api.writable.Writable;
+
+/**
+ * Convert any value to an Integer.
+ *
+ * @author Adam Gibson
+ */
+@NoArgsConstructor
+public class ConvertToDouble extends BaseDoubleTransform {
+    public ConvertToDouble(String column) {
+        super(column);
+    }
+
+    /**
+     * Transform the writable in to a
+     * string
+     *
+     * @param writable the writable to transform
+     * @return the string form of this writable
+     */
+    @Override
+    public DoubleWritable map(Writable writable) {
+        return new DoubleWritable(Double.parseDouble(writable.toString()));
+    }
+
+    /**
+     * Transform an object
+     * in to another object
+     *
+     * @param input the record to transform
+     * @return the transformed writable
+     */
+    @Override
+    public Object map(Object input) {
+        return Double.parseDouble(input.toString());
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/ConvertToDouble.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/ConvertToDouble.java
@@ -1,6 +1,9 @@
 package org.datavec.api.transform.transform.doubletransform;
 
 import lombok.NoArgsConstructor;
+import org.datavec.api.transform.metadata.ColumnMetaData;
+import org.datavec.api.transform.metadata.DoubleMetaData;
+import org.datavec.api.transform.metadata.IntegerMetaData;
 import org.datavec.api.transform.transform.integer.BaseIntegerTransform;
 import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.IntWritable;
@@ -9,7 +12,7 @@ import org.datavec.api.writable.Writable;
 /**
  * Convert any value to an Integer.
  *
- * @author Adam Gibson
+ * @author Justin Long (crockpotveggies)
  */
 @NoArgsConstructor
 public class ConvertToDouble extends BaseDoubleTransform {
@@ -39,5 +42,16 @@ public class ConvertToDouble extends BaseDoubleTransform {
     @Override
     public Object map(Object input) {
         return Double.parseDouble(input.toString());
+    }
+
+
+    @Override
+    public ColumnMetaData getNewColumnMetaData(String newColumnName, ColumnMetaData oldColumnType) {
+        return new DoubleMetaData(newColumnName);
+    }
+
+    @Override
+    public String toString() {
+        return "ConvertToDouble()";
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/BaseIntegerTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/BaseIntegerTransform.java
@@ -18,6 +18,7 @@ package org.datavec.api.transform.transform.integer;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.datavec.api.transform.metadata.ColumnMetaData;
 import org.datavec.api.transform.transform.BaseColumnTransform;
 import org.datavec.api.writable.Writable;
@@ -27,6 +28,7 @@ import org.datavec.api.writable.Writable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
+@NoArgsConstructor
 public abstract class BaseIntegerTransform extends BaseColumnTransform {
 
     public BaseIntegerTransform(String column) {

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/ConvertToInteger.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/ConvertToInteger.java
@@ -1,15 +1,15 @@
 package org.datavec.api.transform.transform.integer;
 
 import lombok.NoArgsConstructor;
-import org.datavec.api.transform.transform.string.BaseStringTransform;
+import org.datavec.api.transform.metadata.ColumnMetaData;
+import org.datavec.api.transform.metadata.IntegerMetaData;
 import org.datavec.api.writable.IntWritable;
-import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
 
 /**
  * Convert any value to an Integer.
  *
- * @author Adam Gibson
+ * @author Justin Long (crockpotveggies)
  */
 @NoArgsConstructor
 public class ConvertToInteger extends BaseIntegerTransform {
@@ -39,5 +39,16 @@ public class ConvertToInteger extends BaseIntegerTransform {
     @Override
     public Object map(Object input) {
         return Integer.parseInt(input.toString());
+    }
+
+
+    @Override
+    public ColumnMetaData getNewColumnMetaData(String newColumnName, ColumnMetaData oldColumnType) {
+        return new IntegerMetaData(newColumnName);
+    }
+
+    @Override
+    public String toString() {
+        return "ConvertToInteger()";
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/ConvertToInteger.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/integer/ConvertToInteger.java
@@ -1,0 +1,43 @@
+package org.datavec.api.transform.transform.integer;
+
+import lombok.NoArgsConstructor;
+import org.datavec.api.transform.transform.string.BaseStringTransform;
+import org.datavec.api.writable.IntWritable;
+import org.datavec.api.writable.Text;
+import org.datavec.api.writable.Writable;
+
+/**
+ * Convert any value to an Integer.
+ *
+ * @author Adam Gibson
+ */
+@NoArgsConstructor
+public class ConvertToInteger extends BaseIntegerTransform {
+    public ConvertToInteger(String column) {
+        super(column);
+    }
+
+    /**
+     * Transform the writable in to a
+     * string
+     *
+     * @param writable the writable to transform
+     * @return the string form of this writable
+     */
+    @Override
+    public IntWritable map(Writable writable) {
+        return new IntWritable(Integer.parseInt(writable.toString()));
+    }
+
+    /**
+     * Transform an object
+     * in to another object
+     *
+     * @param input the record to transform
+     * @return the transformed writable
+     */
+    @Override
+    public Object map(Object input) {
+        return Integer.parseInt(input.toString());
+    }
+}

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -69,7 +69,7 @@ public class CSVRecordReaderTest {
 
     @Test
     public void testReset() throws Exception {
-        CSVRecordReader rr = new CSVRecordReader(0, ",");
+        CSVRecordReader rr = new CSVRecordReader(0, ',');
         rr.initialize(new FileSplit(new ClassPathResource("iris.dat").getFile()));
 
         int nResets = 5;
@@ -89,7 +89,7 @@ public class CSVRecordReaderTest {
 
     @Test
     public void testResetWithSkipLines() throws Exception {
-        CSVRecordReader rr = new CSVRecordReader(10, ",");
+        CSVRecordReader rr = new CSVRecordReader(10, ',');
         rr.initialize(new FileSplit(new ClassPathResource("iris.dat").getFile()));
         int lineCount = 0;
         while (rr.hasNext()) {
@@ -149,7 +149,7 @@ public class CSVRecordReaderTest {
     @Test
     public void testTabsAsSplit1() throws Exception {
 
-        CSVRecordReader reader = new CSVRecordReader(0, "\t");
+        CSVRecordReader reader = new CSVRecordReader(0, '\t');
         reader.initialize(new FileSplit(new ClassPathResource("/tabbed.txt").getFile()));
         while (reader.hasNext()) {
             List<Writable> list = new ArrayList<>(reader.next());
@@ -160,7 +160,7 @@ public class CSVRecordReaderTest {
 
     @Test
     public void testWithQuotes() throws Exception {
-        CSVRecordReader reader = new CSVRecordReader(0, CSVRecordReader.QUOTE_HANDLING_DELIMITER, "\"");
+        CSVRecordReader reader = new CSVRecordReader(0, ',', '\"');
         reader.initialize(new StringSplit("1,0,3,\"Braund, Mr. Owen Harris\",male,\"\"\"\""));
         while (reader.hasNext()) {
             List<Writable> vals = reader.next();
@@ -178,7 +178,7 @@ public class CSVRecordReaderTest {
     @Test
     public void testMeta() throws Exception {
 
-        CSVRecordReader rr = new CSVRecordReader(0, ",");
+        CSVRecordReader rr = new CSVRecordReader(0, ',');
         rr.initialize(new FileSplit(new ClassPathResource("iris.dat").getFile()));
 
         int lineCount = 0;
@@ -247,7 +247,7 @@ public class CSVRecordReaderTest {
         File tempFile = File.createTempFile("csvSkipLines", ".csv");
         FileUtils.writeLines(tempFile, lines);
 
-        CSVRecordReader rr = new CSVRecordReader(numLines, ",");
+        CSVRecordReader rr = new CSVRecordReader(numLines, ',');
         rr.initialize(new FileSplit(tempFile));
         rr.reset();
         assertTrue(!rr.hasNext());
@@ -266,7 +266,7 @@ public class CSVRecordReaderTest {
         File tempFile = File.createTempFile("csvSkipLines", ".csv");
         FileUtils.writeLines(tempFile, lines);
 
-        CSVRecordReader rr = new CSVRecordReader(numLines - 1, ",");
+        CSVRecordReader rr = new CSVRecordReader(numLines - 1, ',');
         rr.initialize(new FileSplit(tempFile));
         rr.reset();
         assertTrue(rr.hasNext());

--- a/datavec-spark/src/test/java/org/datavec/spark/functions/TestLineRecordReaderFunction.java
+++ b/datavec-spark/src/test/java/org/datavec/spark/functions/TestLineRecordReaderFunction.java
@@ -48,13 +48,13 @@ public class TestLineRecordReaderFunction extends BaseSparkTest {
         JavaSparkContext sc = getContext();
         JavaRDD<String> linesRdd = sc.parallelize(lines);
 
-        CSVRecordReader rr = new CSVRecordReader(0, ",");
+        CSVRecordReader rr = new CSVRecordReader(0, ',');
 
         JavaRDD<List<Writable>> out = linesRdd.map(new LineRecordReaderFunction(rr));
         List<List<Writable>> outList = out.collect();
 
 
-        CSVRecordReader rr2 = new CSVRecordReader(0, ",");
+        CSVRecordReader rr2 = new CSVRecordReader(0, ',');
         rr2.initialize(new FileSplit(dataFile));
         Set<List<Writable>> expectedSet = new HashSet<>();
         int totalCount = 0;


### PR DESCRIPTION
## What changes were proposed in this pull request?

To make CSV parsing more user-friendly, I've added some functionality that allows "magic" inference of schema from a sample CSV file. To assist transforms of fields marked as strings, I've added `convertToXnumberX` functions to TransformProcess. Also, CSV parsing was not working well for me, so I've added OpenCSV to the CSVRecordReader and made it serializable.

## How was this patch tested?

Ran CSV tests as well as tried this in my own project on Spark local.
