### PR TITLE
Re-add missing CSVRecordReader constructor (with string delim and quote).

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -103,7 +103,10 @@ public class CSVRecordReader extends LineRecordReader {
      * @param skipNumLines the number of lines to skip
      * @param delimiter the delimiter
      * @param quote the quote to strip
+     * @deprecated This constructor is deprecated; use {@link #CSVRecordReader(int, char)} or
+     * {@link #CSVRecordReader(int, char, char)}
      */
+    @Deprecated
     public CSVRecordReader(int skipNumLines, String delimiter, String quote) {
         this(skipNumLines, stringDelimToChar(delimiter), stringDelimToChar(quote));
     }

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -105,7 +105,7 @@ public class CSVRecordReader extends LineRecordReader {
      * @param quote the quote to strip
      */
     public CSVRecordReader(int skipNumLines, String delimiter, String quote) {
-        this(stringDelimToChar(delimiter), stringDelimToChar(quote));
+        this(skipNumLines, stringDelimToChar(delimiter), stringDelimToChar(quote));
     }
 
     public CSVRecordReader() {

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -98,6 +98,16 @@ public class CSVRecordReader extends LineRecordReader {
         this.csvParser = new SerializableCSVParser(delimiter, quote);
     }
 
+    /**
+     * Skip lines, use delimiter, and strip quotes
+     * @param skipNumLines the number of lines to skip
+     * @param delimiter the delimiter
+     * @param quote the quote to strip
+     */
+    public CSVRecordReader(int skipNumLines, String delimiter, String quote) {
+        this(stringDelimToChar(delimiter), stringDelimToChar(quote));
+    }
+
     public CSVRecordReader() {
         this(0, DEFAULT_DELIMITER);
     }

--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/ConvertToDouble.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/doubletransform/ConvertToDouble.java
@@ -3,10 +3,7 @@ package org.datavec.api.transform.transform.doubletransform;
 import lombok.NoArgsConstructor;
 import org.datavec.api.transform.metadata.ColumnMetaData;
 import org.datavec.api.transform.metadata.DoubleMetaData;
-import org.datavec.api.transform.metadata.IntegerMetaData;
-import org.datavec.api.transform.transform.integer.BaseIntegerTransform;
 import org.datavec.api.writable.DoubleWritable;
-import org.datavec.api.writable.IntWritable;
 import org.datavec.api.writable.Writable;
 import org.datavec.api.writable.WritableType;
 


### PR DESCRIPTION
# What changes were proposed in this pull request?

It's all in the title. @crockpotveggies broke it.

## How was this patch tested?

No tests -- but helps maintain backwards compatibility.
