### PR TITLE
Fix running Spark tests on localhost

### DIFF
--- a/datavec-spark/src/test/java/org/datavec/spark/BaseSparkTest.java
+++ b/datavec-spark/src/test/java/org/datavec/spark/BaseSparkTest.java
@@ -58,7 +58,8 @@ public abstract class BaseSparkTest implements Serializable {
         if (sc != null)
             return sc;
 
-        SparkConf sparkConf = new SparkConf().setMaster("local[*]").set("spark.driverEnv.SPARK_LOCAL_IP", "127.0.0.1")
+        SparkConf sparkConf = new SparkConf().setMaster("local[*]").set("spark.driver.host", "localhost")
+                        .set("spark.driverEnv.SPARK_LOCAL_IP", "127.0.0.1")
                         .set("spark.executorEnv.SPARK_LOCAL_IP", "127.0.0.1").setAppName("sparktest");
 
 


### PR DESCRIPTION
Symptom is binding error on port 0
    (which should never happen except when the driver host is wrong).
