### PR TITLE
Introduce SKIP_BUILD mode to perform-release.sh script

### DIFF
--- a/perform-release.sh
+++ b/perform-release.sh
@@ -9,9 +9,7 @@ fi
 RELEASE_VERSION=$1
 SNAPSHOT_VERSION=$2
 STAGING_REPOSITORY=$3
-if [[ -z ${SKIP_BUILD:-} ]]; then
-    SKIP_BUILD=0
-fi
+SKIP_BUILD=${SKIP_BUILD:-0}
 
 echo "Releasing version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"
 echo "========================================================================================"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -37,9 +37,9 @@ if [[ "${SKIP_BUILD}" == "0" ]]; then
     source change-spark-versions.sh 1
     source change-scala-versions.sh 2.11
 fi
-git commit -a -m "Update to version $RELEASE_VERSION"
-git tag -a -m "datavec-$RELEASE_VERSION" "datavec-$RELEASE_VERSION"
-git tag -a -f -m "datavec-$RELEASE_VERSION" "latest_release"
+git commit -s -a -m "Update to version $RELEASE_VERSION"
+git tag -s -a -m "datavec-$RELEASE_VERSION" "datavec-$RELEASE_VERSION"
+git tag -s -a -f -m "datavec-$RELEASE_VERSION" "latest_release"
 
 sed -i "s/<nd4j.version>.*<\/nd4j.version>/<nd4j.version>$SNAPSHOT_VERSION<\/nd4j.version>/" pom.xml
 #Spark versions, like <version>xxx_spark_2-SNAPSHOT</version>
@@ -48,6 +48,6 @@ for f in $(find . -name 'pom.xml' -not -path '*target*'); do
     sed -i "s/version>.*_spark_.*</version>${SPLIT_VERSION[0]}_spark_1-${SPLIT_VERSION[1]}</g" $f
 done
 mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=$SNAPSHOT_VERSION
-git commit -a -m "Update to version $SNAPSHOT_VERSION"
+git commit -s -a -m "Update to version $SNAPSHOT_VERSION"
 
 echo "Successfully performed release of version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -27,6 +27,8 @@ done
 mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=$RELEASE_VERSION
 
 if [[ "${SKIP_BUILD}" == "0" ]]; then
+    source change-spark-versions.sh 1
+    source change-scala-versions.sh 2.11
     mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -DstagingRepositoryId=$STAGING_REPOSITORY
     source change-spark-versions.sh 2
     mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -DstagingRepositoryId=$STAGING_REPOSITORY


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow updating the source code for a release before making the final build on the "latest_release" tag.

## How was this patch tested?

Build succeeds with source code modified by the script, with no reference to SNAPSHOT artifacts.