### PR TITLE
Fix buildmultiplescalaversions.sh for the Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ deeplearning4j-scaleout/deeplearning4j-aws/src/main/java/org/deeplearning4j/aws/
 .DS_Store
 /logs/
 /datavec-local/src/main/java/org/datavec/local/transforms/TableRecords.java
+**dependency-reduced-pom.xml

--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-BASEDIR=$(dirname $(readlink -f "$0"))
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function echoError() {
     (>&2 echo "$1")


### PR DESCRIPTION
No readlink -f available there without coreutils