### PR TITLE
Align dataframe filter naming

### DIFF
--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/api/CategoryColumn.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/api/CategoryColumn.java
@@ -323,22 +323,12 @@ public class CategoryColumn extends AbstractColumn implements CategoryFilters, C
         return values.isEmpty();
     }
 
+    /**
+     * @deprecated use {@link #isIn(Collection<String>)} instead.  
+     */
+    @Deprecated
     public Selection isInSet(Collection<String> values2) {
-        Selection results = new BitmapBackedSelection();
-        for (String string : values2) {
-            int key = lookupTable.get(string);
-            if (key >= 0) {
-                int i = 0;
-                for (int next : values) {
-                    if (key == next) {
-                        results.add(i);
-                    }
-                    i++;
-                }
-            }
-        }
-
-        return results;
+      return isIn(values2);
     }
 
     public Selection isEqualTo(String string) {
@@ -705,22 +695,47 @@ public class CategoryColumn extends AbstractColumn implements CategoryFilters, C
     }
 
     public Selection isIn(String... strings) {
-        IntArrayList keys = new IntArrayList();
-        for (String string : strings) {
-            int key = lookupTable.get(string);
-            if (key >= 0) {
-                keys.add(key);
-            }
-        }
-
-        int i = 0;
-        Selection results = new BitmapBackedSelection();
-        for (int next : values) {
-            if (keys.contains(next)) {
-                results.add(i);
+      Selection results = new BitmapBackedSelection();
+      for (String string : strings) {
+        int key = lookupTable.get(string);
+        if (key >= 0) {
+          int i = 0;
+          for (int next : values) {
+            if (key == next) {
+              results.add(i);
             }
             i++;
+          }
         }
-        return results;
+      }
+
+      return results;
+    }
+
+    public Selection isIn(Collection<String> strings) {
+      return isIn(strings.toArray(new String[strings.size()]));
+    }
+
+
+    public Selection isNotIn(String... strings) {
+      Selection results = new BitmapBackedSelection();
+      for (String string : strings) {
+        int key = lookupTable.get(string);
+        if (key >= 0) {
+          int i = 0;
+          for (int next : values) {
+            if (key != next) {
+              results.add(i);
+            }
+            i++;
+          }
+        }
+      }
+
+      return results;
+    }
+
+    public Selection isNotIn(Collection<String> strings) {
+      return isNotIn(strings.toArray(new String[strings.size()]));
     }
 }

--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringInSet.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringInSet.java
@@ -1,37 +1,16 @@
 package org.datavec.dataframe.filtering;
 
 import org.datavec.dataframe.api.CategoryColumn;
-import org.datavec.dataframe.api.ColumnType;
-import org.datavec.dataframe.api.Table;
-import org.datavec.dataframe.columns.Column;
 import org.datavec.dataframe.columns.ColumnReference;
-import org.datavec.dataframe.util.Selection;
-
-import java.util.Collection;
 
 /**
- * Implements EqualTo testing for Category and Text Columns
+ * @deprecated use {@link StringIsIn} instead.  
  */
-public class StringInSet extends ColumnFilter {
+@Deprecated
+public class StringInSet extends StringIsIn {
 
-    private Collection<String> values;
-
-    public StringInSet(ColumnReference reference, Collection<String> values) {
-        super(reference);
-        this.values = values;
+    public StringInSet(ColumnReference reference, CategoryColumn filterColumn) {
+        super(reference, filterColumn);
     }
 
-    public Selection apply(Table relation) {
-        Column column = relation.column(columnReference.getColumnName());
-        ColumnType type = column.type();
-        switch (type) {
-            case CATEGORY: {
-                CategoryColumn categoryColumn = (CategoryColumn) relation.column(columnReference.getColumnName());
-                return categoryColumn.isIn(values.toArray(new String[values.size()]));
-            }
-            default:
-                throw new UnsupportedOperationException(
-                                String.format("ColumnType %s does not support equalTo on a String value", type));
-        }
-    }
 }

--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringIsIn.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringIsIn.java
@@ -1,0 +1,41 @@
+package org.datavec.dataframe.filtering;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.datavec.dataframe.api.CategoryColumn;
+import org.datavec.dataframe.api.Table;
+import org.datavec.dataframe.columns.ColumnReference;
+import org.datavec.dataframe.util.Selection;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Implements EqualTo testing for Category and Text Columns
+ */
+public class StringIsIn extends ColumnFilter {
+
+    private CategoryColumn filterColumn;
+
+    public StringIsIn(ColumnReference reference, CategoryColumn filterColumn) {
+        super(reference);
+        this.filterColumn = filterColumn;
+    }
+
+    public StringIsIn(ColumnReference reference, Collection<String> strings) {
+      super(reference);
+      this.filterColumn = CategoryColumn.create("temp", Lists.newArrayList(strings));
+    }
+ 
+    public StringIsIn(ColumnReference reference, String... strings) {
+        super(reference);
+        this.filterColumn = CategoryColumn.create("temp", Lists.newArrayList(strings));
+    }
+
+    public Selection apply(Table relation) {
+        CategoryColumn categoryColumn = (CategoryColumn) relation.column(columnReference.getColumnName());
+        Set<String> firstSet = categoryColumn.asSet();
+        firstSet.retainAll(filterColumn.data());
+        return categoryColumn.select(firstSet::contains);
+    }
+}

--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringIsNotIn.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringIsNotIn.java
@@ -1,0 +1,41 @@
+package org.datavec.dataframe.filtering;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.datavec.dataframe.api.CategoryColumn;
+import org.datavec.dataframe.api.Table;
+import org.datavec.dataframe.columns.ColumnReference;
+import org.datavec.dataframe.util.Selection;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Implements NotEqualTo testing for Category and Text Columns
+ */
+public class StringIsNotIn extends ColumnFilter {
+
+    private CategoryColumn filterColumn;
+
+    public StringIsNotIn(ColumnReference reference, CategoryColumn filterColumn) {
+        super(reference);
+        this.filterColumn = filterColumn;
+    }
+
+    public StringIsNotIn(ColumnReference reference, Collection<String> strings) {
+      super(reference);
+      this.filterColumn = CategoryColumn.create("temp", Lists.newArrayList(strings));
+    }
+ 
+    public StringIsNotIn(ColumnReference reference, String... strings) {
+        super(reference);
+        this.filterColumn = CategoryColumn.create("temp", Lists.newArrayList(strings));
+    }
+
+    public Selection apply(Table relation) {
+        CategoryColumn categoryColumn = (CategoryColumn) relation.column(columnReference.getColumnName());
+        Set<String> firstSet = categoryColumn.asSet();
+        firstSet.removeAll(filterColumn.data());
+        return categoryColumn.select(firstSet::contains);
+    }
+}

--- a/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringNotInSet.java
+++ b/datavec-dataframe/src/main/java/org/datavec/dataframe/filtering/StringNotInSet.java
@@ -1,37 +1,16 @@
 package org.datavec.dataframe.filtering;
 
 import org.datavec.dataframe.api.CategoryColumn;
-import org.datavec.dataframe.api.ColumnType;
-import org.datavec.dataframe.api.Table;
-import org.datavec.dataframe.columns.Column;
 import org.datavec.dataframe.columns.ColumnReference;
-import org.datavec.dataframe.util.Selection;
-
-import java.util.Collection;
 
 /**
- * Implements EqualTo testing for Category and Text Columns
+ * @deprecated use {@link StringIsNotIn} instead.  
  */
-public class StringNotInSet extends ColumnFilter {
+@Deprecated
+public class StringNotInSet extends StringIsNotIn {
 
-    private Collection<String> values;
-
-    public StringNotInSet(ColumnReference reference, Collection<String> values) {
-        super(reference);
-        this.values = values;
+    public StringNotInSet(ColumnReference reference, CategoryColumn filterColumn) {
+        super(reference, filterColumn);
     }
 
-    public Selection apply(Table relation) {
-        Column column = relation.column(columnReference.getColumnName());
-        ColumnType type = column.type();
-        switch (type) {
-            case CATEGORY: {
-                CategoryColumn categoryColumn = (CategoryColumn) relation.column(columnReference.getColumnName());
-                return categoryColumn.isNotInSet(values);
-            }
-            default:
-                throw new UnsupportedOperationException(
-                                String.format("ColumnType %s does not support equalTo on a String value", type));
-        }
-    }
 }

--- a/datavec-local/src/main/java/org/datavec/local/transforms/TableRecords.java
+++ b/datavec-local/src/main/java/org/datavec/local/transforms/TableRecords.java
@@ -253,9 +253,9 @@ public class TableRecords {
                         case NotEqual:
                             return new StringNotEqualTo(columnReference, categoricalColumnCondition.getValue());
                         case InSet:
-                            return new StringInSet(columnReference, categoricalColumnCondition.getSet());
+                            return new StringIsIn(columnReference, categoricalColumnCondition.getSet());
                         case NotInSet:
-                            return new StringNotInSet(columnReference, categoricalColumnCondition.getSet());
+                            return new StringIsNotIn(columnReference, categoricalColumnCondition.getSet());
 
                     }
                 case Long:
@@ -287,9 +287,9 @@ public class TableRecords {
                         case NotEqual:
                             return new StringNotEqualTo(columnReference, categoricalColumnCondition2.getValue());
                         case InSet:
-                            return new StringInSet(columnReference, categoricalColumnCondition2.getSet());
+                            return new StringIsIn(columnReference, categoricalColumnCondition2.getSet());
                         case NotInSet:
-                            return new StringNotInSet(columnReference, categoricalColumnCondition2.getSet());
+                            return new StringIsNotIn(columnReference, categoricalColumnCondition2.getSet());
 
                     }
                 case Float:


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have two methods `isIn` and `IsInSet` that are exactly the same, but have different names. This gives them the same name. This also aligns the naming with naming that is used elsewhere.

This also renames `StringInSet` to `StringIsIn` to be analagous to `IntIsIn`.

Both of these changes align this repo with the upstream.

## How was this patch tested?

Ran `DataVec/datavec-dataframe $ mvn test`
