### PR TITLE
fix return type

### DIFF
--- a/datavec-spark-inference-parent/datavec-spark-inference-client/src/main/java/org/datavec/spark/transform/client/DataVecTransformClient.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-client/src/main/java/org/datavec/spark/transform/client/DataVecTransformClient.java
@@ -235,11 +235,11 @@ public class DataVecTransformClient implements DataVecTransformService {
     @Override
     public SequenceBatchCSVRecord transformSequenceIncremental(BatchCSVRecord transform) {
         try {
-            BatchCSVRecord singleCsvRecord = Unirest.post(url + "/transformincremental")
+            SequenceBatchCSVRecord singleCsvRecord = Unirest.post(url + "/transformincremental")
                     .header("accept", "application/json")
                     .header("Content-Type", "application/json")
                     .header(SEQUENCE_OR_NOT_HEADER,"true")
-                    .body(transform).asObject(BatchCSVRecord.class).getBody();
+                    .body(transform).asObject(SequenceBatchCSVRecord.class).getBody();
             return singleCsvRecord;
         } catch (UnirestException e) {
             e.printStackTrace();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Return type for `/transformincremental` on the client (`DataVecTransformClient`) when `Sequence: True` was wrong.

## How was this patch tested?

First `datavec-spark-inference-client` didn't compile, then after the fix it did.