### PR TITLE
Add variable sliding window CSV record reader

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVVariableSlidingWindowRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVVariableSlidingWindowRecordReader.java
@@ -1,0 +1,235 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.api.records.reader.impl.csv;
+
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.records.Record;
+import org.datavec.api.records.SequenceRecord;
+import org.datavec.api.records.metadata.RecordMetaData;
+import org.datavec.api.records.metadata.RecordMetaDataLineInterval;
+import org.datavec.api.records.reader.SequenceRecordReader;
+import org.datavec.api.split.InputSplit;
+import org.datavec.api.writable.Text;
+import org.datavec.api.writable.Writable;
+import org.nd4j.linalg.primitives.Triple;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+
+/**
+ * A sliding window of variable size across an entire CSV.
+ *
+ * @author Justin Long (crockpotveggies)
+ */
+public class CSVVariableSlidingWindowRecordReader extends CSVRecordReader implements SequenceRecordReader {
+
+    public static final String LINES_PER_SEQUENCE = NAME_SPACE + ".nlinespersequence";
+
+    private int maxLinesPerSequence;
+    private String delimiter;
+    private int stride;
+    private LinkedList<List<Writable>> queue;
+    private boolean exhausted;
+
+    /**
+     * No-arg constructor with the default number of lines per sequence (10)
+     */
+    public CSVVariableSlidingWindowRecordReader() {
+        this(10, 1);
+    }
+
+    /**
+     * @param maxLinesPerSequence    Number of lines in each sequence, use default delemiter(,) between entries in the same line
+     */
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence) {
+        this(maxLinesPerSequence, 0, 1, String.valueOf(CSVRecordReader.DEFAULT_DELIMITER));
+    }
+
+    /**
+     * @param maxLinesPerSequence    Number of lines in each sequence, use default delemiter(,) between entries in the same line
+     */
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int stride) {
+        this(maxLinesPerSequence, 0, stride, String.valueOf(CSVRecordReader.DEFAULT_DELIMITER));
+    }
+
+    /**
+     *
+     * @param maxLinesPerSequence    Number of lines in each sequences
+     * @param skipNumLines         Number of lines to skip at the start of the file (only skipped once, not per sequence)
+     * @param delimiter            Delimiter between entries in the same line, for example ","
+     */
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int skipNumLines, int stride, String delimiter) {
+        super(skipNumLines);
+        this.delimiter = delimiter;
+        this.maxLinesPerSequence = maxLinesPerSequence;
+        this.stride = stride;
+        this.queue = new LinkedList<>();
+        this.exhausted = false;
+    }
+
+    @Override
+    public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
+        super.initialize(conf, split);
+        this.maxLinesPerSequence = conf.getInt(LINES_PER_SEQUENCE, maxLinesPerSequence);
+    }
+
+    @Override
+    public boolean hasNext() {
+        boolean moreInCsv = super.hasNext();
+        boolean moreInQueue = !queue.isEmpty();
+        return moreInCsv || moreInQueue;
+    }
+
+    @Override
+    public List<List<Writable>> sequenceRecord() {
+        List<List<Writable>> sequence = new ArrayList<>();
+
+        // try polling next(), otherwise empty the queue
+        // loop according to stride size
+        for(int i = 0; i < stride; i++) {
+            if(super.hasNext())
+                queue.add(super.next());
+            else
+                exhausted = true;
+
+            if (exhausted && queue.size() < 1)
+                throw new NoSuchElementException("No next element");
+
+            if (queue.size() > maxLinesPerSequence || exhausted)
+                queue.poll();
+        }
+
+        for(List<Writable> line : queue) {
+            sequence.add(line);
+        }
+
+        Collections.reverse(sequence);
+        return sequence;
+    }
+
+    @Override
+    public List<List<Writable>> sequenceRecord(URI uri, DataInputStream dataInputStream) throws IOException {
+        throw new UnsupportedOperationException("Reading CSV data from DataInputStream not yet implemented");
+    }
+
+    @Override
+    public SequenceRecord nextSequence() {
+        int lineBefore = lineIndex;
+        List<List<Writable>> record = sequenceRecord();
+        int lineAfter = lineIndex;
+        URI uri = (locations == null || locations.length < 1 ? null : locations[splitIndex]);
+        RecordMetaData meta = new RecordMetaDataLineInterval(lineBefore, lineAfter - 1, uri,
+                        CSVVariableSlidingWindowRecordReader.class);
+        return new org.datavec.api.records.impl.SequenceRecord(record, meta);
+    }
+
+    @Override
+    public SequenceRecord loadSequenceFromMetaData(RecordMetaData recordMetaData) throws IOException {
+        return loadSequenceFromMetaData(Collections.singletonList(recordMetaData)).get(0);
+    }
+
+    @Override
+    public List<SequenceRecord> loadSequenceFromMetaData(List<RecordMetaData> recordMetaDatas) throws IOException {
+        //First: create a sorted list of the RecordMetaData
+        List<Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>>> list = new ArrayList<>();
+        Iterator<RecordMetaData> iter = recordMetaDatas.iterator();
+        int count = 0;
+        while (iter.hasNext()) {
+            RecordMetaData rmd = iter.next();
+            if (!(rmd instanceof RecordMetaDataLineInterval)) {
+                throw new IllegalArgumentException(
+                                "Invalid metadata; expected RecordMetaDataLineInterval instance; got: " + rmd);
+            }
+            list.add(new Triple<>(count++, (RecordMetaDataLineInterval) rmd,
+                            (List<List<Writable>>) new ArrayList<List<Writable>>()));
+        }
+
+        //Sort by starting line number:
+        Collections.sort(list, new Comparator<Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>>>() {
+            @Override
+            public int compare(Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>> o1,
+                            Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>> o2) {
+                return Integer.compare(o1.getSecond().getLineNumberStart(), o2.getSecond().getLineNumberStart());
+            }
+        });
+
+        Iterator<String> lineIter = getIterator(0); //TODO handle multi file case...
+        int currentLineIdx = 0;
+        String line = lineIter.next();
+        while (currentLineIdx < skipNumLines) {
+            line = lineIter.next();
+            currentLineIdx++;
+        }
+        for (Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>> next : list) {
+            int nextStartLine = next.getSecond().getLineNumberStart();
+            int nextEndLine = next.getSecond().getLineNumberEnd();
+            while (currentLineIdx < nextStartLine && lineIter.hasNext()) {
+                line = lineIter.next();
+                currentLineIdx++;
+            }
+            while (currentLineIdx <= nextEndLine && (lineIter.hasNext() || currentLineIdx == nextEndLine)) {
+                String[] split = line.split(this.delimiter, -1);
+                List<Writable> writables = new ArrayList<>();
+                for (String s : split) {
+                    writables.add(new Text(s));
+                }
+                next.getThird().add(writables);
+                currentLineIdx++;
+                if (lineIter.hasNext()) {
+                    line = lineIter.next();
+                }
+            }
+        }
+        closeIfRequired(lineIter);
+
+        //Now, sort by the original order:
+        Collections.sort(list, new Comparator<Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>>>() {
+            @Override
+            public int compare(Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>> o1,
+                            Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>> o2) {
+                return Integer.compare(o1.getFirst(), o2.getFirst());
+            }
+        });
+
+        //And return...
+        List<SequenceRecord> out = new ArrayList<>();
+        for (Triple<Integer, RecordMetaDataLineInterval, List<List<Writable>>> t : list) {
+            out.add(new org.datavec.api.records.impl.SequenceRecord(t.getThird(), t.getSecond()));
+        }
+
+        return out;
+    }
+
+    @Override
+    public Record loadFromMetaData(RecordMetaData recordMetaData) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public List<Record> loadFromMetaData(List<RecordMetaData> recordMetaDatas) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        queue = new LinkedList<>();
+        exhausted = false;
+    }
+}

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVVariableSlidingWindowRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVVariableSlidingWindowRecordReaderTest.java
@@ -1,0 +1,80 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.api.records.reader.impl;
+
+import org.datavec.api.records.SequenceRecord;
+import org.datavec.api.records.metadata.RecordMetaData;
+import org.datavec.api.records.reader.SequenceRecordReader;
+import org.datavec.api.records.reader.impl.csv.CSVNLinesSequenceRecordReader;
+import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
+import org.datavec.api.records.reader.impl.csv.CSVVariableSlidingWindowRecordReader;
+import org.datavec.api.split.FileSplit;
+import org.datavec.api.util.ClassPathResource;
+import org.datavec.api.writable.Writable;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for variable sliding window csv reader.
+ *
+ * @author Justin Long (crockpotveggies)
+ */
+public class CSVVariableSlidingWindowRecordReaderTest {
+
+    @Test
+    public void testCSVVariableSlidingWindowRecordReader() throws Exception {
+        int maxLinesPerSequence = 3;
+
+        SequenceRecordReader seqRR = new CSVVariableSlidingWindowRecordReader(maxLinesPerSequence, 1);
+        seqRR.initialize(new FileSplit(new ClassPathResource("iris.dat").getFile()));
+
+        CSVRecordReader rr = new CSVRecordReader();
+        rr.initialize(new FileSplit(new ClassPathResource("iris.dat").getFile()));
+
+        int count = 0;
+        while (seqRR.hasNext()) {
+            List<List<Writable>> next = seqRR.sequenceRecord();
+
+            if(count==maxLinesPerSequence-1) {
+                List<List<Writable>> expected = new ArrayList<>();
+                for (int i = 0; i < maxLinesPerSequence; i++) {
+                    expected.add(rr.next());
+                }
+                Collections.reverse(expected);
+                assertEquals(expected, next);
+
+            }
+            if(count==maxLinesPerSequence) {
+                assertEquals(maxLinesPerSequence, next.size());
+            }
+            if(count==0) { // first seq should be length 1
+                assertEquals(1, next.size());
+            }
+            if(count==151) { // last seq should be length 1
+                assertEquals(1, next.size());
+            }
+
+            count++;
+        }
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds support for sliding windows across CSV files. Windows are variable in length, according to index being read. User can also set "stride" of window.

## How was this patch tested?

See added tests. Currently passing.
