### PR TITLE
Add missing JSON annotations to AppendStringColumnTransform

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/transform/transform/string/AppendStringColumnTransform.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/transform/string/AppendStringColumnTransform.java
@@ -21,6 +21,8 @@ import org.datavec.api.transform.metadata.StringMetaData;
 import org.datavec.api.transform.transform.BaseColumnTransform;
 import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
+import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
  * Append a String to the
@@ -28,11 +30,12 @@ import org.datavec.api.writable.Writable;
  *
  * @author Alex Black
  */
+@JsonIgnoreProperties({"inputSchema", "columnNumber"})
 public class AppendStringColumnTransform extends BaseColumnTransform {
 
     private String toAppend;
 
-    public AppendStringColumnTransform(String columnName, String toAppend) {
+    public AppendStringColumnTransform(@JsonProperty("columnName") String columnName, @JsonProperty("toAppend") String toAppend) {
         super(columnName);
         this.toAppend = toAppend;
     }

--- a/datavec-api/src/test/java/org/datavec/api/transform/transform/TestJsonYaml.java
+++ b/datavec-api/src/test/java/org/datavec/api/transform/transform/TestJsonYaml.java
@@ -66,6 +66,7 @@ public class TestJsonYaml {
                         .addColumnDouble("Dbl2", null, 100.0, true, false).addColumnInteger("Int")
                         .addColumnInteger("Int2", 0, 10).addColumnLong("Long").addColumnLong("Long2", -100L, null)
                         .addColumnString("Str").addColumnString("Str2", "someregexhere", 1, null)
+                        .addColumnString("Str3")
                         .addColumnTime("TimeCol", DateTimeZone.UTC)
                         .addColumnTime("TimeCol2", DateTimeZone.UTC, null, 1000L).build();
 
@@ -75,6 +76,7 @@ public class TestJsonYaml {
 
         TransformProcess tp =
                         new TransformProcess.Builder(schema).categoricalToInteger("Cat").categoricalToOneHot("Cat2")
+                                        .appendStringColumnTransform("Str3", "ToAppend")
                                         .integerToCategorical("Cat", Arrays.asList("State1", "State2"))
                                         .stringToCategorical("Str", Arrays.asList("State1", "State2"))
                                         .duplicateColumn("Str", "Str2a").removeColumns("Str2a")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added JSON annotations to `AppendStringColumnTransform` needed for serialization and deserialization. 

## How was this patch tested?

Added `AppendStringColumnTransform` to the TP in `testToFromJsonYaml()` unit test. Without annotations, the test failed; now, it passes.