### PR TITLE
Equality semantics for Writable types that are a Number

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/writable/ByteWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/ByteWritable.java
@@ -17,6 +17,7 @@
 package org.datavec.api.writable;
 
 
+import com.google.common.math.DoubleMath;
 import org.datavec.api.io.WritableComparable;
 import org.datavec.api.io.WritableComparator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
@@ -57,6 +58,22 @@ public class ByteWritable implements WritableComparable {
 
     public void write(DataOutput out) throws IOException {
         out.writeByte(value);
+    }
+
+    public boolean fuzzyEquals(Writable o, double tolerance) {
+        double other;
+        if (o instanceof IntWritable){
+            other = ((IntWritable) o).toDouble();
+        } else if (o instanceof  LongWritable) {
+            other = ((LongWritable) o).toDouble();
+        } else if (o instanceof ByteWritable) {
+            other = ((ByteWritable) o).toDouble();
+        } else if (o instanceof  DoubleWritable) {
+            other = ((DoubleWritable) o).toDouble();
+        } else if (o instanceof  FloatWritable) {
+            other = ((FloatWritable) o).toDouble();
+        } else { return false; }
+        return DoubleMath.fuzzyEquals(this.value, other, tolerance);
     }
 
     /** Returns true iff <code>o</code> is a ByteWritable with the same value. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/ByteWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/ByteWritable.java
@@ -88,7 +88,7 @@ public class ByteWritable implements WritableComparable {
     }
 
     public int hashCode() {
-        return (int) value;
+        return (int)value;
     }
 
     /** Compares two ByteWritables. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/ByteWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/ByteWritable.java
@@ -61,11 +61,13 @@ public class ByteWritable implements WritableComparable {
 
     /** Returns true iff <code>o</code> is a ByteWritable with the same value. */
     public boolean equals(Object o) {
-        if (!(o instanceof ByteWritable)) {
-            return false;
+        if (o instanceof IntWritable || o instanceof LongWritable) {
+            return new IntWritable(this.value).equals(o);
         }
-        ByteWritable other = (ByteWritable) o;
-        return this.value == other.value;
+        if (o instanceof ByteWritable){
+            ByteWritable other = (ByteWritable) o;
+            return this.value == other.value;
+        } else { return false; }
     }
 
     public int hashCode() {

--- a/datavec-api/src/main/java/org/datavec/api/writable/DoubleWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/DoubleWritable.java
@@ -96,8 +96,8 @@ public class DoubleWritable implements WritableComparable {
     }
 
     public int hashCode() {
-        // defer to the Double hashCode, which does a Double.doubleTolongBits(value).hashCode() behind the scenes
-        return Double.valueOf(value).hashCode();
+        long var2 = Double.doubleToLongBits(value);
+        return (int)(var2 ^ var2 >>> 32);
     }
 
     public int compareTo(Object o) {

--- a/datavec-api/src/main/java/org/datavec/api/writable/DoubleWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/DoubleWritable.java
@@ -65,15 +65,22 @@ public class DoubleWritable implements WritableComparable {
      * Returns true iff <code>o</code> is a DoubleWritable with the same value.
      */
     public boolean equals(Object o) {
-        if (!(o instanceof DoubleWritable)) {
+        if (o instanceof  DoubleWritable){
+            DoubleWritable other = (DoubleWritable) o;
+            return this.value == other.value;
+        }
+        if (o instanceof FloatWritable){
+            FloatWritable other = (FloatWritable) o;
+            float thisFloat = (float) this.value;
+            return (this.value == thisFloat && other.get() == thisFloat);
+        } else {
             return false;
         }
-        DoubleWritable other = (DoubleWritable) o;
-        return this.value == other.value;
     }
 
     public int hashCode() {
-        return (int) Double.doubleToLongBits(value);
+        // defer to the Double hashCode, which does a Double.doubleTolongBits(value).hashCode() behind the scenes
+        return Double.valueOf(value).hashCode();
     }
 
     public int compareTo(Object o) {

--- a/datavec-api/src/main/java/org/datavec/api/writable/DoubleWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/DoubleWritable.java
@@ -17,6 +17,7 @@
 package org.datavec.api.writable;
 
 
+import com.google.common.math.DoubleMath;
 import org.datavec.api.io.WritableComparable;
 import org.datavec.api.io.WritableComparator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
@@ -59,6 +60,22 @@ public class DoubleWritable implements WritableComparable {
 
     public double get() {
         return value;
+    }
+
+    public boolean fuzzyEquals(Writable o, double tolerance) {
+        double other;
+        if (o instanceof IntWritable){
+            other = ((IntWritable) o).toDouble();
+        } else if (o instanceof  LongWritable) {
+            other = ((LongWritable) o).toDouble();
+        } else if (o instanceof ByteWritable) {
+            other = ((ByteWritable) o).toDouble();
+        } else if (o instanceof  DoubleWritable) {
+            other = ((DoubleWritable) o).toDouble();
+        } else if (o instanceof  FloatWritable) {
+            other = ((FloatWritable) o).toDouble();
+        } else { return false; }
+        return DoubleMath.fuzzyEquals(this.value, other, tolerance);
     }
 
     /**

--- a/datavec-api/src/main/java/org/datavec/api/writable/FloatWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/FloatWritable.java
@@ -17,6 +17,7 @@
 package org.datavec.api.writable;
 
 
+import com.google.common.math.DoubleMath;
 import org.datavec.api.io.WritableComparable;
 import org.datavec.api.io.WritableComparator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
@@ -57,6 +58,22 @@ public class FloatWritable implements WritableComparable {
 
     public void write(DataOutput out) throws IOException {
         out.writeFloat(value);
+    }
+
+    public boolean fuzzyEquals(Writable o, double tolerance) {
+        double other;
+        if (o instanceof IntWritable){
+            other = ((IntWritable) o).toDouble();
+        } else if (o instanceof  LongWritable) {
+            other = ((LongWritable) o).toDouble();
+        } else if (o instanceof ByteWritable) {
+            other = ((ByteWritable) o).toDouble();
+        } else if (o instanceof  DoubleWritable) {
+            other = ((DoubleWritable) o).toDouble();
+        } else if (o instanceof  FloatWritable) {
+            other = ((FloatWritable) o).toDouble();
+        } else { return false; }
+        return DoubleMath.fuzzyEquals(this.value, other, tolerance);
     }
 
     /** Returns true iff <code>o</code> is a FloatWritable with the same value. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/FloatWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/FloatWritable.java
@@ -61,14 +61,22 @@ public class FloatWritable implements WritableComparable {
 
     /** Returns true iff <code>o</code> is a FloatWritable with the same value. */
     public boolean equals(Object o) {
-        if (!(o instanceof FloatWritable))
+        if (o instanceof FloatWritable){
+            FloatWritable other = (FloatWritable) o;
+            return this.value == other.value;
+        }
+        if (o instanceof DoubleWritable){
+            DoubleWritable other = (DoubleWritable) o;
+            float otherFloat = (float) other.get();
+            return (other.get() == otherFloat && this.value == otherFloat);
+        } else {
             return false;
-        FloatWritable other = (FloatWritable) o;
-        return this.value == other.value;
+        }
     }
 
     public int hashCode() {
-        return Float.floatToIntBits(value);
+        // defer to Float.hashCode, which does what we mean for it to do
+        return Float.valueOf(value).hashCode();
     }
 
     /** Compares two FloatWritables. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/FloatWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/FloatWritable.java
@@ -93,7 +93,7 @@ public class FloatWritable implements WritableComparable {
 
     public int hashCode() {
         // defer to Float.hashCode, which does what we mean for it to do
-        return Float.valueOf(value).hashCode();
+        return Float.floatToIntBits(value);
     }
 
     /** Compares two FloatWritables. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/IntWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/IntWritable.java
@@ -61,6 +61,10 @@ public class IntWritable implements WritableComparable {
 
     /** Returns true iff <code>o</code> is a IntWritable with the same value. */
     public boolean equals(Object o) {
+        if (o instanceof  ByteWritable){
+            ByteWritable other = (ByteWritable) o;
+            return  this.value == other.get();
+        }
         if (o instanceof IntWritable) {
             IntWritable other = (IntWritable) o;
             return this.value == other.get();

--- a/datavec-api/src/main/java/org/datavec/api/writable/IntWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/IntWritable.java
@@ -17,6 +17,7 @@
 package org.datavec.api.writable;
 
 
+import com.google.common.math.DoubleMath;
 import org.datavec.api.io.WritableComparable;
 import org.datavec.api.io.WritableComparator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
@@ -57,6 +58,22 @@ public class IntWritable implements WritableComparable {
 
     public void write(DataOutput out) throws IOException {
         out.writeInt(value);
+    }
+
+    public boolean fuzzyEquals(Writable o, double tolerance) {
+        double other;
+        if (o instanceof IntWritable){
+            other = ((IntWritable) o).toDouble();
+        } else if (o instanceof  LongWritable) {
+            other = ((LongWritable) o).toDouble();
+        } else if (o instanceof ByteWritable) {
+            other = ((ByteWritable) o).toDouble();
+        } else if (o instanceof  DoubleWritable) {
+            other = ((DoubleWritable) o).toDouble();
+        } else if (o instanceof  FloatWritable) {
+            other = ((FloatWritable) o).toDouble();
+        } else { return false; }
+        return DoubleMath.fuzzyEquals(this.value, other, tolerance);
     }
 
     /** Returns true iff <code>o</code> is a IntWritable with the same value. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/IntWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/IntWritable.java
@@ -61,10 +61,16 @@ public class IntWritable implements WritableComparable {
 
     /** Returns true iff <code>o</code> is a IntWritable with the same value. */
     public boolean equals(Object o) {
-        if (!(o instanceof IntWritable))
+        if (o instanceof IntWritable) {
+            IntWritable other = (IntWritable) o;
+            return this.value == other.get();
+        }
+        if (o instanceof LongWritable) {
+            LongWritable other = (LongWritable) o;
+            return this.value == other.get();
+        } else {
             return false;
-        IntWritable other = (IntWritable) o;
-        return this.value == other.value;
+        }
     }
 
     public int hashCode() {

--- a/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
@@ -60,14 +60,20 @@ public class LongWritable implements WritableComparable {
 
     /** Returns true iff <code>o</code> is a LongWritable with the same value. */
     public boolean equals(Object o) {
-        if (!(o instanceof LongWritable))
-            return false;
-        LongWritable other = (LongWritable) o;
-        return this.value == other.value;
+        if (o instanceof LongWritable){
+            LongWritable other = (LongWritable) o;
+            return this.value == other.get();
+        }
+        if (o instanceof IntWritable){
+            IntWritable other = (IntWritable) o;
+            return this.value == other.get();
+        }
+        else { return false; }
     }
 
     public int hashCode() {
-        return (int) value;
+        // Defer to the long hashCode, which collides with integer hashCodes on relevant values
+        return Long.valueOf(value).hashCode();
     }
 
     /** Compares two LongWritables. */
@@ -133,4 +139,5 @@ public class LongWritable implements WritableComparable {
     public WritableType getType() {
         return WritableType.Long;
     }
+
 }

--- a/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
@@ -60,6 +60,10 @@ public class LongWritable implements WritableComparable {
 
     /** Returns true iff <code>o</code> is a LongWritable with the same value. */
     public boolean equals(Object o) {
+        if (o instanceof ByteWritable){
+            ByteWritable other = (ByteWritable) o;
+            return this.value == other.get();
+        }
         if (o instanceof LongWritable){
             LongWritable other = (LongWritable) o;
             return this.value == other.get();

--- a/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
@@ -93,8 +93,8 @@ public class LongWritable implements WritableComparable {
     }
 
     public int hashCode() {
-        // Defer to the long hashCode, which collides with integer hashCodes on relevant values
-        return Long.valueOf(value).hashCode();
+        // copy the long hashCode
+        return (int)(value ^ value >>> 32);
     }
 
     /** Compares two LongWritables. */

--- a/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/LongWritable.java
@@ -17,6 +17,7 @@
 package org.datavec.api.writable;
 
 
+import com.google.common.math.DoubleMath;
 import org.datavec.api.io.WritableComparable;
 import org.datavec.api.io.WritableComparator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
@@ -56,6 +57,22 @@ public class LongWritable implements WritableComparable {
 
     public void write(DataOutput out) throws IOException {
         out.writeLong(value);
+    }
+
+    public boolean fuzzyEquals(Writable o, double tolerance) {
+        double other;
+        if (o instanceof IntWritable){
+            other = ((IntWritable) o).toDouble();
+        } else if (o instanceof  LongWritable) {
+            other = ((LongWritable) o).toDouble();
+        } else if (o instanceof ByteWritable) {
+            other = ((ByteWritable) o).toDouble();
+        } else if (o instanceof  DoubleWritable) {
+            other = ((DoubleWritable) o).toDouble();
+        } else if (o instanceof  FloatWritable) {
+            other = ((FloatWritable) o).toDouble();
+        } else { return false; }
+        return DoubleMath.fuzzyEquals(this.value, other, tolerance);
     }
 
     /** Returns true iff <code>o</code> is a LongWritable with the same value. */

--- a/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -6,6 +6,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 public class WritableTest {
 
@@ -28,7 +30,24 @@ public class WritableTest {
 
     @Test
     public void testIntLongWritable() {
-        assertEquals(new IntWritable(1), new LongWritable(1));
-        assertEquals(new LongWritable(1), new IntWritable(1));
+        assertEquals(new IntWritable(1), new LongWritable(1l));
+        assertEquals(new LongWritable(2l), new IntWritable(2));
+
+        long l = 1L << 34;
+        // those would cast to the same Int
+        assertNotEquals(new LongWritable(l), new IntWritable(4));
+    }
+
+
+    @Test
+    public void testDoubleFloatWritable(){
+        assertEquals(new DoubleWritable(1d), new FloatWritable(1f));
+        assertEquals(new FloatWritable(2f), new DoubleWritable(2d));
+
+        // we defer to Java equality for Floats
+        assertNotEquals(new DoubleWritable(1.1d), new FloatWritable(1.1f));
+        // same idea as above
+        assertNotEquals(new DoubleWritable(1.1d), new FloatWritable((float)1.1d));
+
     }
 }

--- a/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -1,0 +1,34 @@
+package org.datavec.api.writable;
+
+import org.datavec.api.writable.comparator.TextWritableComparator;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.junit.Assert.assertEquals;
+
+public class WritableTest {
+
+    @Test
+    public void testWritableEqualityReflexive() {
+        assertEquals(new IntWritable(1), new IntWritable(1));
+        assertEquals(new LongWritable(1), new LongWritable(1));
+        assertEquals(new DoubleWritable(1), new DoubleWritable(1));
+        assertEquals(new FloatWritable(1), new FloatWritable(1));
+        assertEquals(new Text("Hello"), new Text("Hello"));
+
+        INDArray ndArray = Nd4j.rand(new int[]{1, 100});
+
+        assertEquals(new NDArrayWritable(ndArray), new NDArrayWritable(ndArray));
+        assertEquals(new NullWritable(), new NullWritable());
+        assertEquals(new BooleanWritable(true), new BooleanWritable(true));
+        byte b = 0;
+        assertEquals(new ByteWritable(b), new ByteWritable(b));
+    }
+
+    @Test
+    public void testIntLongWritable() {
+        assertEquals(new IntWritable(1), new LongWritable(1));
+        assertEquals(new LongWritable(1), new IntWritable(1));
+    }
+}

--- a/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -5,9 +5,7 @@ import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 public class WritableTest {
 
@@ -61,6 +59,19 @@ public class WritableTest {
         assertNotEquals(new DoubleWritable(1.1d), new FloatWritable(1.1f));
         // same idea as above
         assertNotEquals(new DoubleWritable(1.1d), new FloatWritable((float)1.1d));
+
+    }
+
+
+    @Test
+    public void testFuzzies(){
+        assertTrue(new DoubleWritable(1.1d).fuzzyEquals(new FloatWritable(1.1f), 1e-6d));
+        assertTrue(new FloatWritable(1.1f).fuzzyEquals(new DoubleWritable(1.1d), 1e-6d));
+        byte b = 0xfffffffe;
+        assertTrue(new ByteWritable(b).fuzzyEquals(new DoubleWritable(-2.0), 1e-6d));
+        assertFalse(new IntWritable(1).fuzzyEquals(new FloatWritable(1.1f), 1e-2d));
+        assertTrue(new IntWritable(1).fuzzyEquals(new FloatWritable(1.05f), 1e-1d));
+        assertTrue(new LongWritable(1).fuzzyEquals(new DoubleWritable(1.05f), 1e-1d));
 
     }
 }

--- a/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -60,6 +60,7 @@ public class WritableTest {
         // same idea as above
         assertNotEquals(new DoubleWritable(1.1d), new FloatWritable((float)1.1d));
 
+        assertNotEquals(new DoubleWritable((double)Float.MAX_VALUE + 1), new FloatWritable(Float.POSITIVE_INFINITY));
     }
 
 

--- a/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -29,6 +29,19 @@ public class WritableTest {
     }
 
     @Test
+    public void testByteWritable() {
+        byte b = 0xfffffffe;
+        assertEquals(new IntWritable(-2), new ByteWritable(b));
+        assertEquals(new LongWritable(-2), new ByteWritable(b));
+        assertEquals(new ByteWritable(b), new IntWritable(-2));
+        assertEquals(new ByteWritable(b), new LongWritable(-2));
+
+        // those would cast to the same Int
+        byte minus126 = 0xffffff82;
+        assertNotEquals(new ByteWritable(minus126), new IntWritable(130));
+    }
+
+    @Test
     public void testIntLongWritable() {
         assertEquals(new IntWritable(1), new LongWritable(1l));
         assertEquals(new LongWritable(2l), new IntWritable(2));


### PR DESCRIPTION
- ensures `hashCode` and `equals` reflects the semantics of the value for `(Byte|Int|Long|Double|Float)Writable`
- adds a facade to `fuzzyEquals` (Guava) for those types

Fixes #265 