### PR TITLE
Allow leading zeros for NumberedFileInputSplit 

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
@@ -1,19 +1,3 @@
-/*-
- *  * Copyright 2016 Skymind, Inc.
- *  *
- *  *    Licensed under the Apache License, Version 2.0 (the "License");
- *  *    you may not use this file except in compliance with the License.
- *  *    You may obtain a copy of the License at
- *  *
- *  *        http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *    Unless required by applicable law or agreed to in writing, software
- *  *    distributed under the License is distributed on an "AS IS" BASIS,
- *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *    See the License for the specific language governing permissions and
- *  *    limitations under the License.
- */
-
 package org.datavec.api.split;
 
 import org.datavec.api.util.files.UriFromPathIterator;
@@ -26,6 +10,8 @@ import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**InputSplit for sequences of numbered files.
  * Example usages:<br>
@@ -39,6 +25,8 @@ public class NumberedFileInputSplit implements InputSplit {
     private final int minIdx;
     private final int maxIdx;
 
+    private static final Pattern p = Pattern.compile("\\%(0\\d)?d");
+
     /**
      * @param baseString String that defines file format. Must contain "%d", which will be replaced with
      *                   the index of the file.
@@ -46,8 +34,9 @@ public class NumberedFileInputSplit implements InputSplit {
      * @param maxIdxInclusive Maximum index/number (last number in sequence of files, inclusive)
      */
     public NumberedFileInputSplit(String baseString, int minIdxInclusive, int maxIdxInclusive) {
-        if (baseString == null || !baseString.contains("%d")) {
-            throw new IllegalArgumentException("Base String must contain  character sequence %d");
+        Matcher m = p.matcher(baseString);
+        if (baseString == null || !m.find()) {
+            throw new IllegalArgumentException("Base String must match this regular expression: " + p.toString());
         }
         this.baseString = baseString;
         this.minIdx = minIdxInclusive;

--- a/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
@@ -1,3 +1,20 @@
+/*-
+ *  * Copyright 2016 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+
 package org.datavec.api.split;
 
 import org.datavec.api.util.files.UriFromPathIterator;
@@ -29,9 +46,10 @@ public class NumberedFileInputSplit implements InputSplit {
 
     /**
      * @param baseString String that defines file format. Must contain "%d", which will be replaced with
-     *                   the index of the file.
+     *                   the index of the file, possibly zero-padded to x digits if the pattern is in the form %0xd.
      * @param minIdxInclusive Minimum index/number (starting number in sequence of files, inclusive)
      * @param maxIdxInclusive Maximum index/number (last number in sequence of files, inclusive)
+     *                        @see {NumberedFileInputSplitTest}
      */
     public NumberedFileInputSplit(String baseString, int minIdxInclusive, int maxIdxInclusive) {
         Matcher m = p.matcher(baseString);

--- a/datavec-api/src/test/java/org/datavec/api/split/NumberedFileInputSplitTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/NumberedFileInputSplitTests.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 public class NumberedFileInputSplitTests {
     @Test
     public void testNumberedFileInputSplitBasic() {
-        String baseString = "/path/to/files/prefix-%d.suffix";
+        String baseString = "/path/to/files/prefix%d.suffix";
         int minIdx = 0;
         int maxIdx = 10;
         runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
@@ -24,8 +24,24 @@ public class NumberedFileInputSplitTests {
     }
 
     @Test
+    public void testNumberedFileInputSplitBasicNoPrefix() {
+        String baseString = "/path/to/files/%d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test
     public void testNumberedFileInputSplitWithLeadingZeroes() {
         String baseString = "/path/to/files/prefix-%07d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test
+    public void testNumberedFileInputSplitWithLeadingZeroesNoSuffix() {
+        String baseString = "/path/to/files/prefix-%d";
         int minIdx = 0;
         int maxIdx = 10;
         runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);

--- a/datavec-api/src/test/java/org/datavec/api/split/NumberedFileInputSplitTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/NumberedFileInputSplitTests.java
@@ -1,0 +1,51 @@
+package org.datavec.api.split;
+
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+public class NumberedFileInputSplitTests {
+    @Test
+    public void testNumberedFileInputSplitBasic() {
+        String baseString = "/path/to/files/prefix-%d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test
+    public void testNumberedFileInputSplitVaryIndeces() {
+        String baseString = "/path/to/files/prefix-%d.suffix";
+        int minIdx = 3;
+        int maxIdx = 27;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test
+    public void testNumberedFileInputSplitWithLeadingZeroes() {
+        String baseString = "/path/to/files/prefix-%07d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithLeadingSpaces() {
+        String baseString = "/path/to/files/prefix-%5d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    private static void runNumberedFileInputSplitTest(String baseString, int minIdx, int maxIdx) {
+        NumberedFileInputSplit split = new NumberedFileInputSplit(baseString, minIdx, maxIdx);
+        URI[] locs = split.locations();
+        assertEquals(locs.length, (maxIdx - minIdx) + 1);
+        int j = 0;
+        for (int i = minIdx; i <= maxIdx; i++) {
+            assertEquals(String.format(baseString, i), locs[j++].getPath());
+        }
+    }
+}

--- a/datavec-api/src/test/java/org/datavec/api/split/NumberedFileInputSplitTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/NumberedFileInputSplitTests.java
@@ -55,6 +55,55 @@ public class NumberedFileInputSplitTests {
         runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithNoLeadingZeroInPadding() {
+        String baseString = "/path/to/files/prefix%5d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithLeadingPlusInPadding() {
+        String baseString = "/path/to/files/prefix%+5d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithLeadingMinusInPadding() {
+        String baseString = "/path/to/files/prefix%-5d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithTwoDigitsInPadding() {
+        String baseString = "/path/to/files/prefix%011d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithInnerZerosInPadding() {
+        String baseString = "/path/to/files/prefix%101d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNumberedFileInputSplitWithRepeatInnerZerosInPadding() {
+        String baseString = "/path/to/files/prefix%0505d.suffix";
+        int minIdx = 0;
+        int maxIdx = 10;
+        runNumberedFileInputSplitTest(baseString, minIdx, maxIdx);
+    }
+
+
     private static void runNumberedFileInputSplitTest(String baseString, int minIdx, int maxIdx) {
         NumberedFileInputSplit split = new NumberedFileInputSplit(baseString, minIdx, maxIdx);
         URI[] locs = split.locations();


### PR DESCRIPTION
## What changes were proposed in this pull request?

With these changes, NumberedFileInputSplit permits two kinds of formatting -- "prefix4.suffix" or "prefix0004.suffix." Latter is more suitable for, e.g., Hadoop mapfiles spit out by a Spark ETL pipeline.

## How was this patch tested?

Added a NumberedFileInputSplitTests class with some unit tests to verify the name formatting works. I've also run it in live code, and it performed fine.