### PR TITLE
treat exceptions from /transformincrementalarray like all others

### DIFF
--- a/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
@@ -145,6 +145,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformSequenceArrayIncremental(record)));
                 } catch (Exception e) {
+                    e.printStackTrace();
                     return internalServerError();
                 }
             } else {
@@ -154,6 +155,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformArrayIncremental(record)));
                 } catch (Exception e) {
+                    e.printStackTrace();
                     return internalServerError();
                 }
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`/transformincrementalarray` of `CSVSparkTransformServer` wasn't writing a stack trace on caught exception. This fixes it.

## How was this patch tested?

Doesn't really need testing, considering it's `e.printStackTrace()` ...