### PR TITLE
Add support for ImageTransform to ObjectDetectionRecordReader

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
@@ -73,6 +73,7 @@ public class ObjectDetectionRecordReader extends BaseImageRecordReader {
     }
 
     /**
+     * When imageTransform != null, object is removed if new center is outside of transformed image bounds.
      *
      * @param height        Height of the output images
      * @param width         Width of the output images

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
+import org.datavec.image.transform.ImageTransform;
 
 import static org.nd4j.linalg.indexing.NDArrayIndex.all;
 import static org.nd4j.linalg.indexing.NDArrayIndex.point;
@@ -69,6 +70,25 @@ public class ObjectDetectionRecordReader extends BaseImageRecordReader {
         this.gridH = gridH;
         this.labelProvider = labelProvider;
 
+    }
+
+    /**
+     *
+     * @param height        Height of the output images
+     * @param width         Width of the output images
+     * @param channels      Number of channels for the output images
+     * @param gridH         Grid/quantization size (along  height dimension) - Y axis
+     * @param gridW         Grid/quantization size (along  height dimension) - X axis
+     * @param labelProvider ImageObjectLabelProvider - used to look up which objects are in each image
+     * @param imageTransform ImageTransform - used to transform image and coordinates
+     */
+    public ObjectDetectionRecordReader(int height, int width, int channels, int gridH, int gridW,
+                ImageObjectLabelProvider labelProvider, ImageTransform imageTransform) {
+        super(height, width, channels, null);
+        this.gridW = gridW;
+        this.gridH = gridH;
+        this.labelProvider = labelProvider;
+        this.imageTransform = imageTransform;
     }
 
     @Override
@@ -147,6 +167,15 @@ public class ObjectDetectionRecordReader extends BaseImageRecordReader {
 
                 //put the label data into the output label array
                 for (ImageObject io : objectsThisImg) {
+                    if (imageTransform != null) {
+                        float[] pts = imageTransform.query(io.getX1(), io.getY1(), io.getX2(), io.getY2());
+                        io = new ImageObject(Math.round(pts[0]), Math.round(pts[1]), Math.round(pts[2]), Math.round(pts[3]), io.getLabel());
+                        double cx = io.getXCenterPixels();
+                        double cy = io.getYCenterPixels();
+                        if (cx < 0 || cx >= oW || cy < 0 || cy >= oH) {
+                            continue;
+                        }
+                    }
                     double cx = io.getXCenterPixels();
                     double cy = io.getYCenterPixels();
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BaseImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BaseImageTransform.java
@@ -45,4 +45,8 @@ public abstract class BaseImageTransform<F> implements ImageTransform {
         return transform(image, random);
     }
 
+    @Override
+    public float[] query(float... coordinates) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
@@ -93,5 +93,7 @@ public class ColorConversionTransform extends BaseImageTransform {
         return new ImageWritable(converter.convert(result));
     }
 
-
+    public float[] query(float... coordinates) {
+        return coordinates;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ColorConversionTransform.java
@@ -93,6 +93,7 @@ public class ColorConversionTransform extends BaseImageTransform {
         return new ImageWritable(converter.convert(result));
     }
 
+    @Override
     public float[] query(float... coordinates) {
         return coordinates;
     }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/CropImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/CropImageTransform.java
@@ -38,6 +38,9 @@ public class CropImageTransform extends BaseImageTransform<Mat> {
     private int cropBottom;
     private int cropRight;
 
+    private int x;
+    private int y;
+
     /** Calls {@code this(null, crop, crop, crop, crop)}. */
     public CropImageTransform(int crop) {
         this(null, crop, crop, crop, crop);
@@ -91,8 +94,8 @@ public class CropImageTransform extends BaseImageTransform<Mat> {
         int bottom = random != null ? random.nextInt(cropBottom + 1) : cropBottom;
         int right = random != null ? random.nextInt(cropRight + 1) : cropRight;
 
-        int y = Math.min(top, mat.rows() - 1);
-        int x = Math.min(left, mat.cols() - 1);
+        y = Math.min(top, mat.rows() - 1);
+        x = Math.min(left, mat.cols() - 1);
         int h = Math.max(1, mat.rows() - bottom - y);
         int w = Math.max(1, mat.cols() - right - x);
         Mat result = mat.apply(new Rect(x, y, w, h));
@@ -100,4 +103,13 @@ public class CropImageTransform extends BaseImageTransform<Mat> {
         return new ImageWritable(converter.convert(result));
     }
 
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            transformed[i    ] = coordinates[i    ] - x;
+            transformed[i + 1] = coordinates[i + 1] - y;
+        }
+        return transformed;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
@@ -102,6 +102,7 @@ public class EqualizeHistTransform extends BaseImageTransform {
         return new ImageWritable(converter.convert(result));
     }
 
+    @Override
     public float[] query(float... coordinates) {
         return coordinates;
     }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/EqualizeHistTransform.java
@@ -102,6 +102,7 @@ public class EqualizeHistTransform extends BaseImageTransform {
         return new ImageWritable(converter.convert(result));
     }
 
-
-
+    public float[] query(float... coordinates) {
+        return coordinates;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/FlipImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/FlipImageTransform.java
@@ -40,6 +40,10 @@ public class FlipImageTransform extends BaseImageTransform<Mat> {
      */
     private int flipMode;
 
+    private int h;
+    private int w;
+    private int mode;
+
     /**
      * Calls {@code this(null)}.
      */
@@ -77,8 +81,10 @@ public class FlipImageTransform extends BaseImageTransform<Mat> {
             return null;
         }
         Mat mat = converter.convert(image.getFrame());
+        h = mat.rows();
+        w = mat.cols();
 
-        int mode = random != null ? random.nextInt(4) - 2 : flipMode;
+        mode = random != null ? random.nextInt(4) - 2 : flipMode;
 
         Mat result = new Mat();
         if (mode < -1) {
@@ -89,6 +95,32 @@ public class FlipImageTransform extends BaseImageTransform<Mat> {
         }
 
         return new ImageWritable(converter.convert(result));
+    }
+
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            float x = coordinates[i    ];
+            float y = coordinates[i + 1];
+            float x2 = w - x - 1;
+            float y2 = h - y - 1;
+
+            if (mode < -1) {
+                transformed[i    ] = x;
+                transformed[i + 1] = y;
+            } else if (mode == 0) {
+                transformed[i    ] = x;
+                transformed[i + 1] = y2;
+            } else if (mode > 0) {
+                transformed[i    ] = x2;
+                transformed[i + 1] = y;
+            } else if (mode < 0) {
+                transformed[i    ] = x2;
+                transformed[i + 1] = y2;
+            }
+        }
+        return transformed;
     }
 }
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ImageTransform.java
@@ -60,4 +60,12 @@ public interface ImageTransform {
      */
     ImageWritable transform(ImageWritable image, Random random);
 
+    /**
+     * Transforms the given coordinates using the parameters that were used to transform the last image.
+     *
+     * @param coordinates to transforms (x1, y1, x2, y2, ...)
+     * @return            transformed coordinates
+     */
+    float[] query(float... coordinates);
+
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/LargestBlobCropTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/LargestBlobCropTransform.java
@@ -41,6 +41,9 @@ public class LargestBlobCropTransform extends BaseImageTransform<Mat> {
     protected int mode, method, blurWidth, blurHeight, upperThresh, lowerThresh;
     protected boolean isCanny;
 
+    private int x;
+    private int y;
+
     /** Calls {@code this(null}*/
     public LargestBlobCropTransform() {
         this(null);
@@ -121,8 +124,20 @@ public class LargestBlobCropTransform extends BaseImageTransform<Mat> {
         }
 
         //Apply crop and return result
+        x = boundingRect.x();
+        y = boundingRect.y();
         Mat result = original.apply(boundingRect);
 
         return new ImageWritable(converter.convert(result));
+    }
+
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            transformed[i    ] = coordinates[i    ] - x;
+            transformed[i + 1] = coordinates[i + 1] - y;
+        }
+        return transformed;
     }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/MultiImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/MultiImageTransform.java
@@ -33,6 +33,7 @@ public class MultiImageTransform extends BaseImageTransform<Mat> {
         return transform.transform(image);
     }
 
+    @Override
     public float[] query(float... coordinates) {
         return transform.query(coordinates);
     }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/MultiImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/MultiImageTransform.java
@@ -32,4 +32,8 @@ public class MultiImageTransform extends BaseImageTransform<Mat> {
     public ImageWritable transform(ImageWritable image) {
         return transform.transform(image);
     }
+
+    public float[] query(float... coordinates) {
+        return transform.query(coordinates);
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
@@ -111,6 +111,7 @@ public class PipelineImageTransform extends BaseImageTransform<Mat> {
         return image;
     }
 
+    @Override
     public float[] query(float... coordinates) {
         for (Pair<ImageTransform, Double> tuple : imageTransforms) {
             coordinates = tuple.getFirst().query(coordinates);

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
@@ -111,6 +111,13 @@ public class PipelineImageTransform extends BaseImageTransform<Mat> {
         return image;
     }
 
+    public float[] query(float... coordinates) {
+        for (Pair<ImageTransform, Double> tuple : imageTransforms) {
+            coordinates = tuple.getFirst().query(coordinates);
+        }
+        return coordinates;
+    }
+
     /**
      * Optional builder helper for PipelineImageTransform
      */

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/RandomCropTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/RandomCropTransform.java
@@ -41,6 +41,9 @@ public class RandomCropTransform extends BaseImageTransform<Mat> {
     protected int outputWidth;
     protected org.nd4j.linalg.api.rng.Random rng;
 
+    private int x;
+    private int y;
+
     public RandomCropTransform(@JsonProperty("outputHeight") int height, @JsonProperty("outputWidth") int width) {
         this(1234, height, width);
     }
@@ -85,12 +88,21 @@ public class RandomCropTransform extends BaseImageTransform<Mat> {
         int top = rng.nextInt(cropTop + 1);
         int left = rng.nextInt(cropLeft + 1);
 
-        int y = Math.min(top, mat.rows() - 1);
-        int x = Math.min(left, mat.cols() - 1);
+        y = Math.min(top, mat.rows() - 1);
+        x = Math.min(left, mat.cols() - 1);
         Mat result = mat.apply(new Rect(x, y, outputWidth, outputHeight));
 
 
         return new ImageWritable(converter.convert(result));
     }
 
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            transformed[i    ] = coordinates[i    ] - x;
+            transformed[i + 1] = coordinates[i + 1] - y;
+        }
+        return transformed;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ResizeImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ResizeImageTransform.java
@@ -15,7 +15,6 @@
  */
 package org.datavec.image.transform;
 
-import org.bytedeco.javacpp.opencv_core;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.data.ImageWritable;
 import org.nd4j.shade.jackson.annotation.JsonInclude;
@@ -23,7 +22,8 @@ import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 import java.util.Random;
 
-import static org.bytedeco.javacpp.opencv_imgproc.resize;
+import static org.bytedeco.javacpp.opencv_core.*;
+import static org.bytedeco.javacpp.opencv_imgproc.*;
 
 /**
  * ResizeImageTransform is suited to force the <b>same image size</b> for whole pipeline
@@ -35,10 +35,13 @@ import static org.bytedeco.javacpp.opencv_imgproc.resize;
  * @author raver119@gmail.com
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ResizeImageTransform extends BaseImageTransform<opencv_core.Mat> {
+public class ResizeImageTransform extends BaseImageTransform<Mat> {
 
     private int newHeight;
     private int newWidth;
+
+    private int srch;
+    private int srcw;
 
     /**
      * Returns new ResizeImageTransform object
@@ -78,11 +81,21 @@ public class ResizeImageTransform extends BaseImageTransform<opencv_core.Mat> {
         if (image == null) {
             return null;
         }
-        opencv_core.Mat mat = converter.convert(image.getFrame());
-        opencv_core.Mat result = new opencv_core.Mat();
-        resize(mat, result, new opencv_core.Size(newWidth, newHeight));
+        Mat mat = converter.convert(image.getFrame());
+        Mat result = new Mat();
+        srch = mat.rows();
+        srcw = mat.cols();
+        resize(mat, result, new Size(newWidth, newHeight));
         return new ImageWritable(converter.convert(result));
     }
 
-
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            transformed[i    ] = newWidth * coordinates[i    ] / srcw;
+            transformed[i + 1] = newHeight * coordinates[i + 1] / srch;
+        }
+        return transformed;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ScaleImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ScaleImageTransform.java
@@ -38,6 +38,9 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
     private float dx;
     private float dy;
 
+    private int srch, h;
+    private int srcw, w;
+
     /** Calls {@code this(null, delta, delta)}. */
     public ScaleImageTransform(float delta) {
         this(null, delta, delta);
@@ -73,12 +76,23 @@ public class ScaleImageTransform extends BaseImageTransform<Mat> {
             return null;
         }
         Mat mat = converter.convert(image.getFrame());
-        int h = Math.round(mat.rows() + dy * (random != null ? 2 * random.nextFloat() - 1 : 1));
-        int w = Math.round(mat.cols() + dx * (random != null ? 2 * random.nextFloat() - 1 : 1));
+        srch = mat.rows();
+        srcw = mat.cols();
+        h = Math.round(mat.rows() + dy * (random != null ? 2 * random.nextFloat() - 1 : 1));
+        w = Math.round(mat.cols() + dx * (random != null ? 2 * random.nextFloat() - 1 : 1));
 
         Mat result = new Mat();
         resize(mat, result, new Size(w, h));
         return new ImageWritable(converter.convert(result));
     }
 
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            transformed[i    ] = w * coordinates[i    ] / srcw;
+            transformed[i + 1] = h * coordinates[i + 1] / srch;
+        }
+        return transformed;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
@@ -91,6 +91,7 @@ public class ShowImageTransform extends BaseImageTransform {
         return image;
     }
 
+    @Override
     public float[] query(float... coordinates) {
         return coordinates;
     }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/ShowImageTransform.java
@@ -91,4 +91,7 @@ public class ShowImageTransform extends BaseImageTransform {
         return image;
     }
 
+    public float[] query(float... coordinates) {
+        return coordinates;
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/WarpImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/WarpImageTransform.java
@@ -15,7 +15,6 @@
  */
 package org.datavec.image.transform;
 
-import java.nio.FloatBuffer;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -26,6 +25,7 @@ import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonInclude;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
+import java.nio.FloatBuffer;
 import java.util.Random;
 
 import static org.bytedeco.javacpp.opencv_core.*;
@@ -131,6 +131,7 @@ public class WarpImageTransform extends BaseImageTransform<Mat> {
         return new ImageWritable(converter.convert(result));
     }
 
+    @Override
     public float[] query(float... coordinates) {
         Mat src = new Mat(1, coordinates.length / 2, CV_32FC2, new FloatPointer(coordinates));
         Mat dst = new Mat();

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/ResizeImageTransformTest.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/ResizeImageTransformTest.java
@@ -29,6 +29,11 @@ public class ResizeImageTransformTest {
         Frame f = dstImg.getFrame();
         assertEquals(f.imageWidth, 200);
         assertEquals(f.imageHeight, 200);
+
+        float[] coordinates = {100, 200};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(200f * 100 / 32, transformed[0], 0);
+        assertEquals(200f * 200 / 32, transformed[1], 0);
     }
 
     @Test
@@ -42,6 +47,11 @@ public class ResizeImageTransformTest {
         Frame f = dstImg.getFrame();
         assertEquals(f.imageWidth, 200);
         assertEquals(f.imageHeight, 200);
+
+        float[] coordinates = {300, 400};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(200f * 300 / 443, transformed[0], 0);
+        assertEquals(200f * 400 / 571, transformed[1], 0);
     }
 
 }

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
@@ -127,6 +127,20 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new WarpImageTransform(1, 2, 3, 4, 5, 6, 7, 8);
+        writable = transform.transform(writable);
+        float[] coordinates = { 0, 0,                                frame.imageWidth, 0,
+                                frame.imageWidth, frame.imageHeight, 0, frame.imageHeight};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(transformed[0], 1, 0);
+        assertEquals(transformed[1], 2, 0);
+        assertEquals(transformed[2], 3 + frame.imageWidth, 0);
+        assertEquals(transformed[3], 4, 0);
+        assertEquals(transformed[4], 5 + frame.imageWidth, 0);
+        assertEquals(transformed[5], 6 + frame.imageHeight, 0);
+        assertEquals(transformed[6], 7, 0);
+        assertEquals(transformed[7], 8 + frame.imageHeight, 0);
     }
 
     @Test

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
@@ -59,6 +59,15 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new CropImageTransform(1, 2, 3, 4);
+        writable = transform.transform(writable);
+        float[] coordinates = {1, 2, 3, 4};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(1 - 2, transformed[0], 0);
+        assertEquals(2 - 1, transformed[1], 0);
+        assertEquals(3 - 2, transformed[2], 0);
+        assertEquals(4 - 1, transformed[3], 0);
     }
 
     @Test
@@ -75,6 +84,30 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new FlipImageTransform(-2);
+        writable = transform.transform(writable);
+        float[] transformed = transform.query(new float[] {10, 20});
+        assertEquals(10, transformed[0], 0);
+        assertEquals(20, transformed[1], 0);
+
+        transform = new FlipImageTransform(0);
+        writable = transform.transform(writable);
+        transformed = transform.query(new float[] {30, 40});
+        assertEquals(30,                         transformed[0], 0);
+        assertEquals(frame.imageHeight - 40 - 1, transformed[1], 0);
+
+        transform = new FlipImageTransform(1);
+        writable = transform.transform(writable);
+        transformed = transform.query(new float[] {50, 60});
+        assertEquals(frame.imageWidth - 50 - 1, transformed[0], 0);
+        assertEquals(60,                        transformed[1], 0);
+
+        transform = new FlipImageTransform(-1);
+        writable = transform.transform(writable);
+        transformed = transform.query(new float[] {70, 80});
+        assertEquals(frame.imageWidth  - 70 - 1, transformed[0], 0);
+        assertEquals(frame.imageHeight - 80 - 1, transformed[1], 0);
     }
 
     @Test
@@ -93,6 +126,15 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new ScaleImageTransform(frame.imageWidth, 2 * frame.imageHeight);
+        writable = transform.transform(writable);
+        float[] coordinates = {5, 7, 11, 13};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(5 * 2,  transformed[0], 0);
+        assertEquals(7 * 3,  transformed[1], 0);
+        assertEquals(11 * 2, transformed[2], 0);
+        assertEquals(13 * 3, transformed[3], 0);
     }
 
     @Test
@@ -110,6 +152,15 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new RotateImageTransform(0, 0, -90, 0);
+        writable = transform.transform(writable);
+        float[] coordinates = {frame.imageWidth / 2, frame.imageHeight / 2, 0, 0};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(frame.imageWidth  / 2, transformed[0], 0);
+        assertEquals(frame.imageHeight / 2, transformed[1], 0);
+        assertEquals((frame.imageHeight + frame.imageWidth) / 2 - 1, transformed[2], 0);
+        assertEquals((frame.imageHeight - frame.imageWidth) / 2,     transformed[3], 0);
     }
 
     @Test
@@ -133,21 +184,21 @@ public class TestImageTransform {
         float[] coordinates = { 0, 0,                                frame.imageWidth, 0,
                                 frame.imageWidth, frame.imageHeight, 0, frame.imageHeight};
         float[] transformed = transform.query(coordinates);
-        assertEquals(transformed[0], 1, 0);
-        assertEquals(transformed[1], 2, 0);
-        assertEquals(transformed[2], 3 + frame.imageWidth, 0);
-        assertEquals(transformed[3], 4, 0);
-        assertEquals(transformed[4], 5 + frame.imageWidth, 0);
-        assertEquals(transformed[5], 6 + frame.imageHeight, 0);
-        assertEquals(transformed[6], 7, 0);
-        assertEquals(transformed[7], 8 + frame.imageHeight, 0);
+        assertEquals(1,                     transformed[0], 0);
+        assertEquals(2,                     transformed[1], 0);
+        assertEquals(3 + frame.imageWidth,  transformed[2], 0);
+        assertEquals(4,                     transformed[3], 0);
+        assertEquals(5 + frame.imageWidth,  transformed[4], 0);
+        assertEquals(6 + frame.imageHeight, transformed[5], 0);
+        assertEquals(7,                     transformed[6], 0);
+        assertEquals(8 + frame.imageHeight, transformed[7], 0);
     }
 
     @Test
     public void testMultiImageTransform() throws Exception {
         ImageWritable writable = makeRandomImage(0, 0, 3);
         Frame frame = writable.getFrame();
-        ImageTransform transform = new PipelineImageTransform(seed, false, new CropImageTransform(10),
+        ImageTransform transform = new MultiImageTransform(rng, new CropImageTransform(10),
                         new FlipImageTransform(), new ScaleImageTransform(10), new WarpImageTransform(10));
 
         for (int i = 0; i < 100; i++) {
@@ -160,6 +211,12 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new MultiImageTransform(new ColorConversionTransform(COLOR_BGR2RGB));
+        writable = transform.transform(writable);
+        float[] transformed = transform.query(new float[] {11, 22});
+        assertEquals(11, transformed[0], 0);
+        assertEquals(22, transformed[1], 0);
     }
 
     @Ignore
@@ -193,6 +250,10 @@ public class TestImageTransform {
         }
 
         assertEquals(null, transform.transform(null));
+
+        float[] transformed = transform.query(new float[] {33, 44});
+        assertEquals(33, transformed[0], 0);
+        assertEquals(44, transformed[1], 0);
     }
 
     @Test
@@ -217,6 +278,10 @@ public class TestImageTransform {
         Frame newframe = w.getFrame();
         assertNotEquals(frame, newframe);
         assertEquals(null, transform.transform(null));
+
+        float[] transformed = transform.query(new float[] {55, 66});
+        assertEquals(55, transformed[0], 0);
+        assertEquals(66, transformed[1], 0);
     }
 
     @Test
@@ -238,6 +303,9 @@ public class TestImageTransform {
         assertNotEquals(frame, newframe);
         assertEquals(null, transform.transform(null));
 
+        float[] transformed = transform.query(new float[] {66, 77});
+        assertEquals(66, transformed[0], 0);
+        assertEquals(77, transformed[1], 0);
     }
 
     @Test
@@ -253,6 +321,15 @@ public class TestImageTransform {
             assertTrue(f.imageWidth == frame.imageWidth / 2);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new RandomCropTransform(frame.imageHeight, frame.imageWidth);
+        writable = transform.transform(writable);
+        float[] coordinates = {2, 4, 6, 8};
+        float[] transformed = transform.query(coordinates);
+        assertEquals(2, transformed[0], 0);
+        assertEquals(4, transformed[1], 0);
+        assertEquals(6, transformed[2], 0);
+        assertEquals(8, transformed[3], 0);
     }
 
     @Test
@@ -275,6 +352,12 @@ public class TestImageTransform {
             assertEquals(f.imageChannels, frame.imageChannels);
         }
         assertEquals(null, transform.transform(null));
+
+        transform = new PipelineImageTransform(new EqualizeHistTransform());
+        writable = transform.transform(writable);
+        float[] transformed = transform.query(new float[] {88, 99});
+        assertEquals(88, transformed[0], 0);
+        assertEquals(99, transformed[1], 0);
     }
 
     /**
@@ -307,6 +390,10 @@ public class TestImageTransform {
 
         assertEquals(newFrame.imageHeight, 74);
         assertEquals(newFrame.imageWidth, 61);
+
+        float[] transformed = transform.query(new float[] {88, 32});
+        assertEquals(0, transformed[0], 0);
+        assertEquals(0, transformed[1], 0);
     }
 
     public static ImageWritable makeRandomImage(int height, int width, int channels) {


### PR DESCRIPTION
WORK IN PROGRESS: DO NOT MERGE.

Related to issue #417 

## What changes were proposed in this pull request?

Add ImageTransform.query(coordinates) method so that ObjectDetectionRecordReader can use it to transform coordinates.

## How was this patch tested?

New unit tests pass.