### PR TITLE
Add Quantiles to Numerical analyses in AnalyzeSpark

### DIFF
--- a/datavec-api/pom.xml
+++ b/datavec-api/pom.xml
@@ -141,8 +141,14 @@
         <dependency>
             <groupId>net.sf.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>2.3</version>
+            <version>${opencsv.version}</version>
         </dependency>
+
+        <dependency>
+         <groupId>com.tdunning</groupId>
+         <artifactId>t-digest</artifactId>
+         <version>${tdigest.version}</version>
+     </dependency>
     </dependencies>
 
     <profiles>

--- a/datavec-api/src/main/java/org/datavec/api/transform/analysis/columns/NumericalColumnAnalysis.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/analysis/columns/NumericalColumnAnalysis.java
@@ -73,7 +73,8 @@ public abstract class NumericalColumnAnalysis implements ColumnAnalysis {
         return "mean=" + mean + ",sampleStDev=" + sampleStdev + ",sampleVariance=" + sampleVariance + ",countZero="
                         + countZero + ",countNegative=" + countNegative + ",countPositive=" + countPositive
                         + ",countMinValue=" + countMinValue + ",countMaxValue=" + countMaxValue + ",count="
-                        + countTotal + ", quantiles=[" + quantiles.toString();
+                        + countTotal + ", quantiles=[" + quantiles.toString() +
+    "]";
     }
 
     public abstract double getMinDouble();

--- a/datavec-api/src/main/java/org/datavec/api/transform/analysis/columns/NumericalColumnAnalysis.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/analysis/columns/NumericalColumnAnalysis.java
@@ -17,7 +17,7 @@
 package org.datavec.api.transform.analysis.columns;
 
 import lombok.Data;
-import com.clearspring.analytics.stream.quantile.TDigest;
+import com.tdunning.math.stats.TDigest;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/datavec-api/src/main/java/org/datavec/api/transform/analysis/columns/NumericalColumnAnalysis.java
+++ b/datavec-api/src/main/java/org/datavec/api/transform/analysis/columns/NumericalColumnAnalysis.java
@@ -17,6 +17,10 @@
 package org.datavec.api.transform.analysis.columns;
 
 import lombok.Data;
+import com.clearspring.analytics.stream.quantile.TDigest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Abstract class for numerical column analysis
@@ -37,6 +41,7 @@ public abstract class NumericalColumnAnalysis implements ColumnAnalysis {
     protected long countTotal;
     protected double[] histogramBuckets;
     protected long[] histogramBucketCounts;
+    protected TDigest digest;
 
     protected NumericalColumnAnalysis(Builder builder) {
         this.mean = builder.mean;
@@ -50,6 +55,7 @@ public abstract class NumericalColumnAnalysis implements ColumnAnalysis {
         this.countTotal = builder.countTotal;
         this.histogramBuckets = builder.histogramBuckets;
         this.histogramBucketCounts = builder.histogramBucketCounts;
+        this.digest = builder.digest;
     }
 
     protected NumericalColumnAnalysis() {
@@ -58,10 +64,16 @@ public abstract class NumericalColumnAnalysis implements ColumnAnalysis {
 
     @Override
     public String toString() {
+        StringBuilder quantiles = new StringBuilder();
+        double[] printReports = new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999};
+        for (int i = 0; i < printReports.length; i++){
+            quantiles.append(printReports[i] +" -> " + digest.quantile(printReports[i]));
+            if (i < printReports.length - 1) quantiles.append(",");
+        }
         return "mean=" + mean + ",sampleStDev=" + sampleStdev + ",sampleVariance=" + sampleVariance + ",countZero="
                         + countZero + ",countNegative=" + countNegative + ",countPositive=" + countPositive
                         + ",countMinValue=" + countMinValue + ",countMaxValue=" + countMaxValue + ",count="
-                        + countTotal;
+                        + countTotal + ", quantiles=[" + quantiles.toString();
     }
 
     public abstract double getMinDouble();
@@ -81,6 +93,7 @@ public abstract class NumericalColumnAnalysis implements ColumnAnalysis {
         protected long countTotal;
         protected double[] histogramBuckets;
         protected long[] histogramBucketCounts;
+        protected TDigest digest;
 
         public T mean(double mean) {
             this.mean = mean;
@@ -136,6 +149,12 @@ public abstract class NumericalColumnAnalysis implements ColumnAnalysis {
             this.histogramBucketCounts = histogramBucketCounts;
             return (T) this;
         }
+
+        public T digest(TDigest digest){
+            this.digest = digest;
+            return (T) this;
+        }
+
     }
 
 }

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/AnalyzeSpark.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/AnalyzeSpark.java
@@ -156,7 +156,7 @@ public class AnalyzeSpark {
                                     .sampleVariance(iac.getSampleVariance()).countZero(iac.getCountZero())
                                     .countNegative(iac.getCountNegative()).countPositive(iac.getCountPositive())
                                     .countMinValue(iac.getCountMinValue()).countMaxValue(iac.getCountMaxValue())
-                                    .countTotal(iac.getCountTotal()).build();
+                                    .countTotal(iac.getCountTotal()).digest(iac.getDigest()).build();
                     list.add(ia);
 
                     minsMaxes[i][0] = iac.getMinValueSeen();
@@ -171,7 +171,7 @@ public class AnalyzeSpark {
                                     .sampleVariance(lac.getSampleVariance()).countZero(lac.getCountZero())
                                     .countNegative(lac.getCountNegative()).countPositive(lac.getCountPositive())
                                     .countMinValue(lac.getCountMinValue()).countMaxValue(lac.getCountMaxValue())
-                                    .countTotal(lac.getCountTotal()).build();
+                                    .countTotal(lac.getCountTotal()).digest(lac.getDigest()).build();
 
                     list.add(la);
 
@@ -186,7 +186,7 @@ public class AnalyzeSpark {
                                     .sampleVariance(dac.getSampleVariance()).countZero(dac.getCountZero())
                                     .countNegative(dac.getCountNegative()).countPositive(dac.getCountPositive())
                                     .countMinValue(dac.getCountMinValue()).countMaxValue(dac.getCountMaxValue())
-                                    .countNaN(dac.getCountNaN()).countTotal(dac.getCountTotal()).build();
+                                    .countNaN(dac.getCountNaN()).digest(dac.getDigest()).countTotal(dac.getCountTotal()).build();
                     list.add(da);
 
                     minsMaxes[i][0] = dac.getMinValueSeen();
@@ -207,7 +207,7 @@ public class AnalyzeSpark {
                                     .sampleVariance(lac2.getSampleVariance()).countZero(lac2.getCountZero())
                                     .countNegative(lac2.getCountNegative()).countPositive(lac2.getCountPositive())
                                     .countMinValue(lac2.getCountMinValue()).countMaxValue(lac2.getCountMaxValue())
-                                    .countTotal(lac2.getCountTotal()).build();
+                                    .countTotal(lac2.getCountTotal()).digest(lac2.getDigest()).build();
 
                     list.add(la2);
 

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/DoubleAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/DoubleAnalysisCounter.java
@@ -16,7 +16,7 @@
 
 package org.datavec.spark.transform.analysis.columns;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
+import com.tdunning.math.stats.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -39,7 +39,15 @@ public class DoubleAnalysisCounter implements AnalysisCounter<DoubleAnalysisCoun
     private long countPositive = 0;
     private long countNegative = 0;
     private long countNaN = 0;
-    private TDigest digest = new TDigest(100);
+  /**
+   * A histogram structure that will record a sketch of a distribution.
+   *
+   * The compression argument regulates how accuracy should be traded for size? A value of N here
+   * will give quantile errors almost always less than 3/N with considerably smaller errors expected
+   * for extreme quantiles. Conversely, you should expect to track about 5 N centroids for this
+   * accuracy.
+   */
+  private TDigest digest = TDigest.createDigest(100);
 
 
     public DoubleAnalysisCounter() {};

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/DoubleAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/DoubleAnalysisCounter.java
@@ -16,6 +16,7 @@
 
 package org.datavec.spark.transform.analysis.columns;
 
+import com.clearspring.analytics.stream.quantile.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -38,6 +39,8 @@ public class DoubleAnalysisCounter implements AnalysisCounter<DoubleAnalysisCoun
     private long countPositive = 0;
     private long countNegative = 0;
     private long countNaN = 0;
+    private TDigest digest = new TDigest(100);
+
 
     public DoubleAnalysisCounter() {};
 
@@ -97,6 +100,7 @@ public class DoubleAnalysisCounter implements AnalysisCounter<DoubleAnalysisCoun
             countNegative++;
         } ;
 
+        digest.add(value);
         counter.merge(value);
 
         return this;
@@ -127,8 +131,10 @@ public class DoubleAnalysisCounter implements AnalysisCounter<DoubleAnalysisCoun
             newCountMaxValue = countMaxValue;
         }
 
+        digest.add(other.getDigest());
+
         return new DoubleAnalysisCounter(counter.merge(other.getCounter()), countZero + other.getCountZero(),
                         newCountMinValue, newCountMaxValue, countPositive + other.getCountPositive(),
-                        countNegative + other.getCountNegative(), countNaN + other.getCountNaN());
+                        countNegative + other.getCountNegative(), countNaN + other.getCountNaN(), digest);
     }
 }

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/IntegerAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/IntegerAnalysisCounter.java
@@ -16,7 +16,7 @@
 
 package org.datavec.spark.transform.analysis.columns;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
+import com.tdunning.math.stats.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -38,7 +38,15 @@ public class IntegerAnalysisCounter implements AnalysisCounter<IntegerAnalysisCo
     private long countMaxValue = 0;
     private long countPositive = 0;
     private long countNegative = 0;
-    private TDigest digest = new TDigest(100);
+    /**
+     * A histogram structure that will record a sketch of a distribution.
+     *
+     * The compression argument regulates how accuracy should be traded for size? A value of N here
+     * will give quantile errors almost always less than 3/N with considerably smaller errors expected
+     * for extreme quantiles. Conversely, you should expect to track about 5 N centroids for this
+     * accuracy.
+     */
+    private TDigest digest = TDigest.createDigest(100);
 
     public IntegerAnalysisCounter() {};
 

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/IntegerAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/IntegerAnalysisCounter.java
@@ -16,6 +16,7 @@
 
 package org.datavec.spark.transform.analysis.columns;
 
+import com.clearspring.analytics.stream.quantile.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -37,6 +38,7 @@ public class IntegerAnalysisCounter implements AnalysisCounter<IntegerAnalysisCo
     private long countMaxValue = 0;
     private long countPositive = 0;
     private long countNegative = 0;
+    private TDigest digest = new TDigest(100);
 
     public IntegerAnalysisCounter() {};
 
@@ -93,6 +95,8 @@ public class IntegerAnalysisCounter implements AnalysisCounter<IntegerAnalysisCo
             countNegative++;
         } ;
 
+        digest.add((double) value);
+
         counter.merge((double) value);
 
         return this;
@@ -123,8 +127,10 @@ public class IntegerAnalysisCounter implements AnalysisCounter<IntegerAnalysisCo
             newCountMaxValue = countMaxValue;
         }
 
+        digest.add(other.getDigest());
+
         return new IntegerAnalysisCounter(counter.merge(other.getCounter()), countZero + other.getCountZero(),
                         newCountMinValue, newCountMaxValue, countPositive + other.getCountPositive(),
-                        countNegative + other.getCountNegative());
+                        countNegative + other.getCountNegative(), digest);
     }
 }

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/LongAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/LongAnalysisCounter.java
@@ -16,6 +16,7 @@
 
 package org.datavec.spark.transform.analysis.columns;
 
+import com.clearspring.analytics.stream.quantile.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -37,6 +38,7 @@ public class LongAnalysisCounter implements AnalysisCounter<LongAnalysisCounter>
     private long countMaxValue = 0;
     private long countPositive = 0;
     private long countNegative = 0;
+    private TDigest digest = new TDigest(100);
 
     public LongAnalysisCounter() {};
 
@@ -93,6 +95,7 @@ public class LongAnalysisCounter implements AnalysisCounter<LongAnalysisCounter>
             countNegative++;
         } ;
 
+        digest.add((double) value);
         counter.merge((double) value);
 
         return this;
@@ -123,8 +126,10 @@ public class LongAnalysisCounter implements AnalysisCounter<LongAnalysisCounter>
             newCountMaxValue = countMaxValue;
         }
 
+        digest.add(other.getDigest());
+
         return new LongAnalysisCounter(counter.merge(other.getCounter()), countZero + other.getCountZero(),
                         newCountMinValue, newCountMaxValue, countPositive + other.getCountPositive(),
-                        countNegative + other.getCountNegative());
+                        countNegative + other.getCountNegative(), digest);
     }
 }

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/LongAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/columns/LongAnalysisCounter.java
@@ -16,7 +16,7 @@
 
 package org.datavec.spark.transform.analysis.columns;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
+import com.tdunning.math.stats.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -38,7 +38,15 @@ public class LongAnalysisCounter implements AnalysisCounter<LongAnalysisCounter>
     private long countMaxValue = 0;
     private long countPositive = 0;
     private long countNegative = 0;
-    private TDigest digest = new TDigest(100);
+    /**
+     * A histogram structure that will record a sketch of a distribution.
+     *
+     * The compression argument regulates how accuracy should be traded for size? A value of N here
+     * will give quantile errors almost always less than 3/N with considerably smaller errors expected
+     * for extreme quantiles. Conversely, you should expect to track about 5 N centroids for this
+     * accuracy.
+     */
+    private TDigest digest = TDigest.createDigest(100);
 
     public LongAnalysisCounter() {};
 

--- a/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/string/StringAnalysisCounter.java
+++ b/datavec-spark/src/main/java/org/datavec/spark/transform/analysis/string/StringAnalysisCounter.java
@@ -16,6 +16,7 @@
 
 package org.datavec.spark.transform.analysis.string;
 
+import com.clearspring.analytics.stream.quantile.TDigest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.spark.util.StatCounter;
@@ -84,6 +85,7 @@ public class StringAnalysisCounter implements AnalysisCounter<StringAnalysisCoun
         else if (length > getMaxLengthSeen()) {
             countMaxLength = 1;
         }
+
         counter.merge((double) length);
 
         return this;

--- a/datavec-spark/src/test/java/org/datavec/spark/transform/analysis/TestAnalysis.java
+++ b/datavec-spark/src/test/java/org/datavec/spark/transform/analysis/TestAnalysis.java
@@ -16,6 +16,7 @@
 
 package org.datavec.spark.transform.analysis;
 
+import com.tdunning.math.stats.TDigest;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.util.StatCounter;
 import org.datavec.api.transform.analysis.DataAnalysis;
@@ -77,16 +78,32 @@ public class TestAnalysis extends BaseSparkTest {
         assertEquals(-1, ia.getMin());
         assertEquals(5, ia.getMax());
         assertEquals(4, ia.getCountTotal());
+        TDigest itd = ia.getDigest();
+        assertEquals(-0.5, itd.quantile(0.25), 1e-9); // right-biased linear approximations w/ few points
+        assertEquals(1.5, itd.quantile(0.5), 1e-9);
+        assertEquals(4.0, itd.quantile(0.75), 1e-9);
+        assertEquals(5.0, itd.quantile(1), 1e-9);
 
         DoubleAnalysis dba = (DoubleAnalysis) ca.get(1);
         assertEquals(-1.0, dba.getMin(), 0.0);
         assertEquals(10.0, dba.getMax(), 0.0);
         assertEquals(4, dba.getCountTotal());
+        TDigest dtd = dba.getDigest();
+        assertEquals(-0.5, dtd.quantile(0.25), 1e-9); // right-biased linear approximations w/ few points
+        assertEquals(0.5, dtd.quantile(0.5), 1e-9);
+        assertEquals(5.5, dtd.quantile(0.75), 1e-9);
+        assertEquals(10.0, dtd.quantile(1), 1e-9);
+
 
         TimeAnalysis ta = (TimeAnalysis) ca.get(2);
         assertEquals(1000, ta.getMin());
         assertEquals(20000, ta.getMax());
         assertEquals(4, ta.getCountTotal());
+        TDigest ttd = ta.getDigest();
+        assertEquals(1500.0, ttd.quantile(0.25), 1e-9); // right-biased linear approximations w/ few points
+        assertEquals(2500.0, ttd.quantile(0.5), 1e-9);
+        assertEquals(11500.0, ttd.quantile(0.75), 1e-9);
+        assertEquals(20000.0, ttd.quantile(1), 1e-9);
 
         CategoricalAnalysis cata = (CategoricalAnalysis) ca.get(3);
         Map<String, Long> map = cata.getMapOfCounts();

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,8 @@
         <maven-git-commit-id-plugin.version>2.2.2</maven-git-commit-id-plugin.version>
         <maven-build-helper-plugin.version>1.12</maven-build-helper-plugin.version>
         <jetbrains-annotations.version>13.0</jetbrains-annotations.version>
+        <opencsv.version>2.3</opencsv.version>
+        <tdigest.version>3.2</tdigest.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Uses T-Digests¹ to lightly track quantiles in the numerical column analysis in Spark. Provides the structure for later replacement of histograms as we implement them (T-Digests can cheaply track a cdf, for which histograms are 1 derivative away).

¹: https://github.com/tdunning/t-digest/

Gives a direction towards fixing #290 

## How was this patch tested?

Extension of the `TestAnalysis` unit test.
