### PR TITLE
Add AndroidNativeImageLoader.asBitmap() and Java2DNativeImageLoader.asBufferedImage()

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/AndroidNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/AndroidNativeImageLoader.java
@@ -17,6 +17,7 @@ package org.datavec.image.loader;
 
 import android.graphics.Bitmap;
 import org.bytedeco.javacv.AndroidFrameConverter;
+import org.bytedeco.javacv.Frame;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.transform.ImageTransform;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -75,4 +76,19 @@ public class AndroidNativeImageLoader extends NativeImageLoader {
         return image instanceof Bitmap ? asMatrix((Bitmap) image) : null;
     }
 
+    /** Returns {@code asBitmap(array, Frame.DEPTH_UBYTE)}. */
+    public Bitmap asBitmap(INDArray array) {
+        return asBitmap(array, Frame.DEPTH_UBYTE);
+    }
+
+    /**
+     * Converts an INDArray to a Bitmap. Only intended for images with rank 3.
+     *
+     * @param array to convert
+     * @param dataType from JavaCV (DEPTH_FLOAT, DEPTH_UBYTE, etc), or -1 to use same type as the INDArray
+     * @return data copied to a Frame
+     */
+    public Bitmap asBitmap(INDArray array, int dataType) {
+        return converter2.convert(asFrame(array, dataType));
+    }
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/Java2DNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/Java2DNativeImageLoader.java
@@ -15,6 +15,7 @@
  */
 package org.datavec.image.loader;
 
+import org.bytedeco.javacv.Frame;
 import org.bytedeco.javacv.Java2DFrameConverter;
 import org.bytedeco.javacv.OpenCVFrameConverter;
 import org.datavec.image.transform.ImageTransform;
@@ -100,4 +101,19 @@ public class Java2DNativeImageLoader extends NativeImageLoader {
         return image instanceof BufferedImage ? asMatrix((BufferedImage) image) : null;
     }
 
+    /** Returns {@code asBufferedImage(array, Frame.DEPTH_UBYTE)}. */
+    public BufferedImage asBufferedImage(INDArray array) {
+        return asBufferedImage(array, Frame.DEPTH_UBYTE);
+    }
+
+    /**
+     * Converts an INDArray to a BufferedImage. Only intended for images with rank 3.
+     *
+     * @param array to convert
+     * @param dataType from JavaCV (DEPTH_FLOAT, DEPTH_UBYTE, etc), or -1 to use same type as the INDArray
+     * @return data copied to a Frame
+     */
+    public BufferedImage asBufferedImage(INDArray array, int dataType) {
+        return converter2.convert(asFrame(array, dataType));
+    }
 }

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -192,6 +192,10 @@ public class TestNativeImageLoader {
         assertEquals(h3, frame.imageHeight);
         assertEquals(ch3, frame.imageChannels);
         assertEquals(Frame.DEPTH_UBYTE, frame.imageDepth);
+
+        Java2DNativeImageLoader loader4 = new Java2DNativeImageLoader();
+        BufferedImage img12 = loader4.asBufferedImage(array1);
+        assertEquals(array1, loader4.asMatrix(img12));
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

To complement NativeImageLoader.asMat()/asFrame().

## How was this patch tested?

Updated unit tests pass.