### PR TITLE
Add BoxImageTransform to pad or crop images instead of resizing

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BoxImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BoxImageTransform.java
@@ -1,0 +1,122 @@
+/*-
+ *  * Copyright 2017 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+package org.datavec.image.transform;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.datavec.image.data.ImageWritable;
+import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
+import org.nd4j.shade.jackson.annotation.JsonInclude;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+import java.util.Random;
+
+import static org.bytedeco.javacpp.opencv_core.*;
+
+/**
+ * Boxes images to a given width and height without changing their aspect ratios,
+ * or resolution, by either padding or cropping them.
+ *
+ * @author saudet
+ */
+@Accessors(fluent = true)
+@JsonIgnoreProperties({"borderValue"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BoxImageTransform extends BaseImageTransform<Mat> {
+
+    private int width;
+    private int height;
+
+    private int x;
+    private int y;
+
+    @Getter
+    @Setter
+    Scalar borderValue = Scalar.ZERO;
+
+    /** Calls {@code this(null, width, height)}. */
+    public BoxImageTransform(@JsonProperty("width") int width, @JsonProperty("height") int height) {
+        this(null, width, height);
+    }
+
+    /**
+     * Constructs an instance of the ImageTransform.
+     *
+     * @param random object to use (or null for deterministic)
+     * @param width  of the boxed image (pixels)
+     * @param height of the boxed image (pixels)
+     */
+    public BoxImageTransform(Random random, int width, int height) {
+        super(random);
+        this.width = width;
+        this.height = height;
+        this.converter = new OpenCVFrameConverter.ToMat();
+    }
+
+    /**
+     * Takes an image and returns a boxed version of the image.
+     *
+     * @param image  to transform, null == end of stream
+     * @param random object to use (or null for deterministic)
+     * @return transformed image
+     */
+    @Override
+    public ImageWritable transform(ImageWritable image, Random random) {
+        if (image == null) {
+            return null;
+        }
+
+        Mat mat = converter.convert(image.getFrame());
+        Mat box = new Mat(height, width, mat.type());
+        box.put(borderValue);
+        x = (mat.cols() - width) / 2;
+        y = (mat.rows() - height) / 2;
+        int w = Math.min(mat.cols(), width);
+        int h = Math.min(mat.rows(), height);
+        Rect matRect = new Rect(x, y, w, h);
+        Rect boxRect = new Rect(x, y, w, h);
+
+        if (x <= 0) {
+            matRect.x(0);
+            boxRect.x(-x);
+        } else {
+            matRect.x(x);
+            boxRect.x(0);
+        }
+
+        if (y <= 0) {
+            matRect.y(0);
+            boxRect.y(-y);
+        } else {
+            matRect.y(y);
+            boxRect.y(0);
+        }
+        mat.apply(matRect).copyTo(box.apply(boxRect));
+        return new ImageWritable(converter.convert(box));
+    }
+
+    @Override
+    public float[] query(float... coordinates) {
+        float[] transformed = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i += 2) {
+            transformed[i    ] = coordinates[i    ] - x;
+            transformed[i + 1] = coordinates[i + 1] - y;
+        }
+        return transformed;
+    }
+}

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BoxImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/BoxImageTransform.java
@@ -30,7 +30,9 @@ import static org.bytedeco.javacpp.opencv_core.*;
 
 /**
  * Boxes images to a given width and height without changing their aspect ratios,
- * or resolution, by either padding or cropping them.
+ * or the size of the objects, by either padding or cropping them from the center.
+ * When the width/height of an image is less than the given width/height, it gets
+ * padded in that dimension, otherwise it gets cropped.
  *
  * @author saudet
  */

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/transform/PipelineImageTransform.java
@@ -82,7 +82,7 @@ public class PipelineImageTransform extends BaseImageTransform<Mat> {
 
     public PipelineImageTransform(Random random, long seed, List<Pair<ImageTransform, Double>> transforms,
                     boolean shuffle) {
-        super(null); // for perf reasons we ignore java Random, create our own
+        super(random); // used by the transforms in the pipeline
         this.imageTransforms = transforms;
         this.shuffle = shuffle;
         this.rng = Nd4j.getRandom();
@@ -104,7 +104,8 @@ public class PipelineImageTransform extends BaseImageTransform<Mat> {
         // execute each item in the pipeline
         for (Pair<ImageTransform, Double> tuple : imageTransforms) {
             if (tuple.getSecond() == 1.0 || rng.nextDouble() < tuple.getSecond()) { // probability of execution
-                image = tuple.getFirst().transform(image);
+                image = random != null ? tuple.getFirst().transform(image, random)
+                                       : tuple.getFirst().transform(image);
             }
         }
 

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
@@ -45,6 +45,35 @@ public class TestImageTransform {
     static final OpenCVFrameConverter.ToMat converter = new OpenCVFrameConverter.ToMat();
 
     @Test
+    public void testBoxImageTransform() throws Exception {
+        ImageTransform transform = new BoxImageTransform(rng, 237, 242).borderValue(Scalar.GRAY);
+
+        for (int i = 0; i < 100; i++) {
+            ImageWritable writable = makeRandomImage(0, 0, i % 4 + 1);
+            Frame frame = writable.getFrame();
+
+            ImageWritable w = transform.transform(writable);
+            Frame f = w.getFrame();
+            assertEquals(237, f.imageWidth);
+            assertEquals(242, f.imageHeight);
+            assertEquals(frame.imageChannels, f.imageChannels);
+
+            float[] coordinates = {1, 2, 3, 4, 0, 0};
+            float[] transformed = transform.query(coordinates);
+            int x = (frame.imageWidth - f.imageWidth) / 2;
+            int y = (frame.imageHeight - f.imageHeight) / 2;
+
+            assertEquals(1 - x, transformed[0], 0);
+            assertEquals(2 - y, transformed[1], 0);
+            assertEquals(3 - x, transformed[2], 0);
+            assertEquals(4 - y, transformed[3], 0);
+            assertEquals(  - x, transformed[4], 0);
+            assertEquals(  - y, transformed[5], 0);
+        }
+        assertEquals(null, transform.transform(null));
+    }
+
+    @Test
     public void testCropImageTransform() throws Exception {
         ImageWritable writable = makeRandomImage(0, 0, 1);
         Frame frame = writable.getFrame();


### PR DESCRIPTION
Fixes #417

## What changes were proposed in this pull request?

Add an alternative fallback to resizing images, one that keeps aspect ratio and size of objects in images by padding and cropping them appropriately from the center.

Also fix PipelineImageTransform not passing Random to transforms

## How was this patch tested?

Unit tests including a new one pass. Also performed visual inspection of results.