### PR TITLE
TransformClient/Server - use TransformProcess.toJson()/fromJson()

### DIFF
--- a/datavec-spark-inference-parent/datavec-spark-inference-client/src/main/java/org/datavec/spark/transform/client/DataVecTransformClient.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-client/src/main/java/org/datavec/spark/transform/client/DataVecTransformClient.java
@@ -4,6 +4,7 @@ import com.mashape.unirest.http.ObjectMapper;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.datavec.api.transform.TransformProcess;
 import org.datavec.image.transform.ImageTransformProcess;
 import org.datavec.spark.transform.model.*;
@@ -16,6 +17,7 @@ import java.io.IOException;
  * Created by agibsonccc on 6/12/17.
  */
 @AllArgsConstructor
+@Slf4j
 public class DataVecTransformClient implements DataVecTransformService {
     private String url;
 
@@ -49,10 +51,12 @@ public class DataVecTransformClient implements DataVecTransformService {
     @Override
     public void setCSVTransformProcess(TransformProcess transformProcess) {
         try {
+            String s = transformProcess.toJson();
             Unirest.post(url + "/transformprocess").header("accept", "application/json")
-                    .header("Content-Type", "application/json").body(transformProcess).asJson();
+                    .header("Content-Type", "application/json").body(s).asJson();
 
         } catch (UnirestException e) {
+            log.error("Error in setCSVTransformProcess()", e);
             e.printStackTrace();
         }
     }
@@ -68,9 +72,11 @@ public class DataVecTransformClient implements DataVecTransformService {
     @Override
     public TransformProcess getCSVTransformProcess() {
         try {
-            return Unirest.get(url + "/transformprocess").header("accept", "application/json")
-                    .header("Content-Type", "application/json").asObject(TransformProcess.class).getBody();
+            String s = Unirest.get(url + "/transformprocess").header("accept", "application/json")
+                    .header("Content-Type", "application/json").asString().getBody();
+            return TransformProcess.fromJson(s);
         } catch (UnirestException e) {
+            log.error("Error in getCSVTransformProcess()",e);
             e.printStackTrace();
         }
 
@@ -95,6 +101,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .body(transform).asObject(SingleCSVRecord.class).getBody();
             return singleCsvRecord;
         } catch (UnirestException e) {
+            log.error("Error in transformIncremental(SingleCSVRecord)",e);
             e.printStackTrace();
         }
         return null;
@@ -114,6 +121,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .getBody();
             return batchCSVRecord1;
         } catch (UnirestException e) {
+            log.error("Error in transform(BatchCSVRecord)", e);
             e.printStackTrace();
         }
 
@@ -132,11 +140,11 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .asObject(Base64NDArrayBody.class).getBody();
             return batchArray1;
         } catch (UnirestException e) {
+            log.error("Error in transformArray(BatchCSVRecord)",e);
             e.printStackTrace();
         }
 
         return null;
-
     }
 
     /**
@@ -151,6 +159,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .body(singleCsvRecord).asObject(Base64NDArrayBody.class).getBody();
             return array;
         } catch (UnirestException e) {
+            log.error("Error in transformArrayIncremental(SingleCSVRecord)",e);
             e.printStackTrace();
         }
 
@@ -181,6 +190,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .body(singleCsvRecord).asObject(Base64NDArrayBody.class).getBody();
             return array;
         } catch (UnirestException e) {
+            log.error("Error in transformSequenceArrayIncremental",e);
             e.printStackTrace();
         }
 
@@ -201,6 +211,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .asObject(Base64NDArrayBody.class).getBody();
             return batchArray1;
         } catch (UnirestException e) {
+            log.error("Error in transformSequenceArray",e);
             e.printStackTrace();
         }
 
@@ -222,6 +233,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .asObject(SequenceBatchCSVRecord.class).getBody();
             return batchCSVRecord1;
         } catch (UnirestException e) {
+            log.error("Error in transformSequence");
             e.printStackTrace();
         }
 
@@ -242,6 +254,7 @@ public class DataVecTransformClient implements DataVecTransformService {
                     .body(transform).asObject(SequenceBatchCSVRecord.class).getBody();
             return singleCsvRecord;
         } catch (UnirestException e) {
+            log.error("Error in transformSequenceIncremental");
             e.printStackTrace();
         }
         return null;

--- a/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
@@ -67,7 +67,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
             try {
                 if (transform == null)
                     return badRequest();
-                return ok(objectMapper.writeValueAsString(transform.getTransformProcess().toJson())).as(contentType);
+                return ok(transform.getTransformProcess().toJson()).as(contentType);
             } catch (Exception e) {
                 log.error("Error in GET /transformprocess",e);
                 return internalServerError(e.getMessage());
@@ -79,7 +79,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                 TransformProcess transformProcess = TransformProcess.fromJson(getJsonText());
                 setCSVTransformProcess(transformProcess);
                 log.info("Transform process initialized");
-                return ok(objectMapper.writeValueAsString(transformProcess)).as(contentType);
+                return ok();
             } catch (Exception e) {
                 log.error("Error in POST /transformprocess",e);
                 return internalServerError(e.getMessage());

--- a/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
+++ b/datavec-spark-inference-parent/datavec-spark-inference-server/src/main/java/org/datavec/spark/transform/CSVSparkTransformServer.java
@@ -67,11 +67,10 @@ public class CSVSparkTransformServer extends SparkTransformServer {
             try {
                 if (transform == null)
                     return badRequest();
-                log.info("Transform process initialized");
-                return ok(objectMapper.writeValueAsString(transform.getTransformProcess())).as(contentType);
+                return ok(objectMapper.writeValueAsString(transform.getTransformProcess().toJson())).as(contentType);
             } catch (Exception e) {
-                e.printStackTrace();
-                return internalServerError();
+                log.error("Error in GET /transformprocess",e);
+                return internalServerError(e.getMessage());
             }
         })));
 
@@ -82,8 +81,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                 log.info("Transform process initialized");
                 return ok(objectMapper.writeValueAsString(transformProcess)).as(contentType);
             } catch (Exception e) {
-                e.printStackTrace();
-                return internalServerError();
+                log.error("Error in POST /transformprocess",e);
+                return internalServerError(e.getMessage());
             }
         })));
 
@@ -95,8 +94,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformSequenceIncremental(record))).as(contentType);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return internalServerError();
+                    log.error("Error in /transformincremental", e);
+                    return internalServerError(e.getMessage());
                 }
             } else {
                 try {
@@ -105,8 +104,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformIncremental(record))).as(contentType);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return internalServerError();
+                    log.error("Error in /transformincremental", e);
+                    return internalServerError(e.getMessage());
                 }
             }
         })));
@@ -119,8 +118,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(batch)).as(contentType);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return internalServerError();
+                    log.error("Error in /transform", e);
+                    return internalServerError(e.getMessage());
                 }
             } else {
                 try {
@@ -129,8 +128,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(batch)).as(contentType);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return internalServerError();
+                    log.error("Error in /transform", e);
+                    return internalServerError(e.getMessage());
                 }
             }
 
@@ -145,8 +144,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformSequenceArrayIncremental(record))).as(contentType);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return internalServerError();
+                    log.error("Error in /transformincrementalarray", e);
+                    return internalServerError(e.getMessage());
                 }
             } else {
                 try {
@@ -155,8 +154,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformArrayIncremental(record))).as(contentType);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return internalServerError();
+                    log.error("Error in /transformincrementalarray", e);
+                    return internalServerError(e.getMessage());
                 }
             }
 
@@ -170,7 +169,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformSequenceArray(batchCSVRecord))).as(contentType);
                 } catch (Exception e) {
-                    return internalServerError();
+                    log.error("Error in /transformarray", e);
+                    return internalServerError(e.getMessage());
                 }
             } else {
                 try {
@@ -179,7 +179,8 @@ public class CSVSparkTransformServer extends SparkTransformServer {
                         return badRequest();
                     return ok(objectMapper.writeValueAsString(transformArray(batchCSVRecord))).as(contentType);
                 } catch (Exception e) {
-                    return internalServerError();
+                    log.error("Error in /transformarray", e);
+                    return internalServerError(e.getMessage());
                 }
             }
         })));
@@ -202,6 +203,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
 
     @Override
     public void setImageTransformProcess(ImageTransformProcess imageTransformProcess) {
+        log.error("Unsupported operation: setImageTransformProcess not supported for class", getClass());
         throw new UnsupportedOperationException("Invalid operation for " + this.getClass());
     }
 
@@ -215,6 +217,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
 
     @Override
     public ImageTransformProcess getImageTransformProcess() {
+        log.error("Unsupported operation: getImageTransformProcess not supported for class", getClass());
         throw new UnsupportedOperationException("Invalid operation for " + this.getClass());
     }
 
@@ -285,6 +288,7 @@ public class CSVSparkTransformServer extends SparkTransformServer {
         try {
             return this.transform.toArray(batchCSVRecord);
         } catch (IOException e) {
+            log.error("Error in transformArray",e);
             throw new IllegalStateException("Transform array shouldn't throw exception");
         }
     }
@@ -298,17 +302,20 @@ public class CSVSparkTransformServer extends SparkTransformServer {
         try {
             return this.transform.toArray(singleCsvRecord);
         } catch (IOException e) {
+            log.error("Error in transformArrayIncremental",e);
             throw new IllegalStateException("Transform array shouldn't throw exception");
         }
     }
 
     @Override
     public Base64NDArrayBody transformIncrementalArray(SingleImageRecord singleImageRecord) throws IOException {
+        log.error("Unsupported operation: transformIncrementalArray(SingleImageRecord) not supported for class", getClass());
         throw new UnsupportedOperationException("Invalid operation for " + this.getClass());
     }
 
     @Override
     public Base64NDArrayBody transformArray(BatchImageRecord batchImageRecord) throws IOException {
+        log.error("Unsupported operation: transformArray(BatchImageRecord) not supported for class", getClass());
         throw new UnsupportedOperationException("Invalid operation for " + this.getClass());
     }
 }


### PR DESCRIPTION
Should be OK to merge as-is.

To avoid issues with the ObjectMapper implementation/configuration, consistently use the TransformProcess.toJson()/fromJson() methods.

Also log errors, to aid with debugging when run remotely.