### PR TITLE
Allow for rounding errors in TestImageTransform.testRotateImageTransform()

### DIFF
--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/transform/TestImageTransform.java
@@ -188,8 +188,8 @@ public class TestImageTransform {
         float[] transformed = transform.query(coordinates);
         assertEquals(frame.imageWidth  / 2, transformed[0], 0);
         assertEquals(frame.imageHeight / 2, transformed[1], 0);
-        assertEquals((frame.imageHeight + frame.imageWidth) / 2 - 1, transformed[2], 0);
-        assertEquals((frame.imageHeight - frame.imageWidth) / 2,     transformed[3], 0);
+        assertEquals((frame.imageHeight + frame.imageWidth) / 2, transformed[2], 1);
+        assertEquals((frame.imageHeight - frame.imageWidth) / 2, transformed[3], 1);
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix potentially failing unit test.

## How was this patch tested?

Unit tests pass.
