### PR TITLE
Spectrogram fft fix

### DIFF
--- a/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/dsp/FastFourierTransform.java
+++ b/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/dsp/FastFourierTransform.java
@@ -28,10 +28,16 @@ public class FastFourierTransform {
     /**
      * Get the frequency intensities
      *
-     * @param amplitudes real-valued amplitudes of the signal
+     * @param amplitudes amplitudes of the signal. Format depends on value of complex
+     * @param complex if true, amplitudes is assumed to be complex interlaced (re = even, im = odd), if false amplitudes
+     *                are assumed to be real valued.
      * @return intensities of each frequency unit: mag[frequency_unit]=intensity
      */
-    public double[] getMagnitudesForReal(double[] amplitudes) {
+    public double[] getMagnitudes(double[] amplitudes, boolean complex) {
+
+        if(complex) {
+            return getMagnitudes(amplitudes);
+        }
 
         // FFT expects complex input where even indexes are real parts
         // and odd indexes are img parts.
@@ -43,7 +49,7 @@ public class FastFourierTransform {
             amplitudesAsComplex[j] = amplitudes[j / 2];
             amplitudesAsComplex[j + 1] = 0;
         }
-        return getMagnitudesForComplex(amplitudesAsComplex);
+        return getMagnitudes(amplitudesAsComplex);
     }
 
     /**
@@ -52,7 +58,7 @@ public class FastFourierTransform {
      * @param amplitudes complex-valued signal to transform. Even indexes are real and odd indexes are img
      * @return intensities of each frequency unit: mag[frequency_unit]=intensity
      */
-    public double[] getMagnitudesForComplex(double[] amplitudes) {
+    public double[] getMagnitudes(double[] amplitudes) {
 
         int sampleSize = amplitudes.length;
 

--- a/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/extension/Spectrogram.java
+++ b/datavec-data/datavec-data-audio/src/main/java/org/datavec/audio/extension/Spectrogram.java
@@ -125,7 +125,7 @@ public class Spectrogram {
         // for each frame in signals, do fft on it
         FastFourierTransform fft = new FastFourierTransform();
         for (int i = 0; i < numFrames; i++) {
-            absoluteSpectrogram[i] = fft.getMagnitudesForReal(signals[i]);
+            absoluteSpectrogram[i] = fft.getMagnitudes(signals[i], false);
         }
 
         if (absoluteSpectrogram.length > 0) {

--- a/datavec-data/datavec-data-audio/src/test/java/org/datavec/audio/TestFastFourierTransform.java
+++ b/datavec-data/datavec-data-audio/src/test/java/org/datavec/audio/TestFastFourierTransform.java
@@ -20,15 +20,13 @@ import org.datavec.audio.dsp.FastFourierTransform;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
-
 public class TestFastFourierTransform {
 
     @Test
     public void testFastFourierTransformComplex() {
         FastFourierTransform fft = new FastFourierTransform();
         double[] amplitudes = new double[] {3.0, 4.0, 0.5, 7.8, 6.9, -6.5, 8.5, 4.6};
-        double[] frequencies = fft.getMagnitudesForComplex(amplitudes);
+        double[] frequencies = fft.getMagnitudes(amplitudes);
 
         Assert.assertEquals(2, frequencies.length);
         Assert.assertArrayEquals(new double[] {21.335, 18.513}, frequencies, 0.005);
@@ -38,7 +36,7 @@ public class TestFastFourierTransform {
     public void testFastFourierTransformReal() {
         FastFourierTransform fft = new FastFourierTransform();
         double[] amplitudes = new double[] {3.0, 4.0, 0.5, 7.8, 6.9, -6.5, 8.5, 4.6};
-        double[] frequencies = fft.getMagnitudesForReal(amplitudes);
+        double[] frequencies = fft.getMagnitudes(amplitudes, false);
 
         Assert.assertEquals(4, frequencies.length);
         Assert.assertArrayEquals(new double[] {28.8, 2.107, 14.927, 19.874}, frequencies, 0.005);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes for issue #502 

Length of each timewindow in Spectrogram now is same sa fftSampleSize.
FastFourierTransform has a method which takes a real-valued signal. I left the old behaviour (which assumed complex valued) since there was a testcase for it already. 

## How was this patch tested?

New testcase for FFT added, although it has magic numbers in it. Manual inspection in debugger to see that change of real to complex format expected by FFT is correct.
Spectrogram windowing was tested manually by (temporarily) adding amplitudes as argument to buildSpectrogram, commenting out calling it from constructor and a main method like this:
    public static void main(String[] args) {
        Spectrogram spec = new Spectrogram(null, 4,2);
        short[] testVec = {0,1,2,3,4,5,6,7};
        spec.buildSpectrogram(testVec);
    } 

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
