### PR TITLE
Change of FFT implementation to Jtransforms

### DIFF
--- a/datavec-data/datavec-data-audio/src/test/java/org/datavec/audio/TestFastFourierTransform.java
+++ b/datavec-data/datavec-data-audio/src/test/java/org/datavec/audio/TestFastFourierTransform.java
@@ -33,6 +33,16 @@ public class TestFastFourierTransform {
     }
 
     @Test
+    public void testFastFourierTransformComplexLong() {
+        FastFourierTransform fft = new FastFourierTransform();
+        double[] amplitudes = new double[] {3.0, 4.0, 0.5, 7.8, 6.9, -6.5, 8.5, 4.6};
+        double[] frequencies = fft.getMagnitudes(amplitudes, true);
+
+        Assert.assertEquals(4, frequencies.length);
+        Assert.assertArrayEquals(new double[] {21.335, 18.5132, 14.927, 7.527}, frequencies, 0.005);
+    }
+
+    @Test
     public void testFastFourierTransformReal() {
         FastFourierTransform fft = new FastFourierTransform();
         double[] amplitudes = new double[] {3.0, 4.0, 0.5, 7.8, 6.9, -6.5, 8.5, 4.6};
@@ -40,5 +50,15 @@ public class TestFastFourierTransform {
 
         Assert.assertEquals(4, frequencies.length);
         Assert.assertArrayEquals(new double[] {28.8, 2.107, 14.927, 19.874}, frequencies, 0.005);
+    }
+
+    @Test
+    public void testFastFourierTransformRealOddSize() {
+        FastFourierTransform fft = new FastFourierTransform();
+        double[] amplitudes = new double[] {3.0, 4.0, 0.5, 7.8, 6.9, -6.5, 8.5};
+        double[] frequencies = fft.getMagnitudes(amplitudes, false);
+
+        Assert.assertEquals(3, frequencies.length);
+        Assert.assertArrayEquals(new double[] {24.2, 3.861, 16.876}, frequencies, 0.005);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <jetbrains-annotations.version>13.0</jetbrains-annotations.version>
         <opencsv.version>2.3</opencsv.version>
         <tdigest.version>3.2</tdigest.version>
+        <jtransforms.version>3.1</jtransforms.version>
     </properties>
 
     <repositories>
@@ -693,6 +694,12 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.github.wendykierp</groupId>
+          <artifactId>JTransforms</artifactId>
+          <version>${jtransforms.version}</version>
+          <classifier>with-dependencies</classifier>
       </dependency>
     </dependencies>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed FFT implementation to JTransforms as discussed in #505.
I might have gone a bit overboard with the backwards compatibility this time around: Previous implementation returned an array which was four times smaller than the input when input was complex. 
This is what you get with the method without the boolean argument while the one with the boolean arg returns an array of half the size as the input for both complex and real amplitudes. 

## How was this patch tested?

Unit tests

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
