### PR TITLE
Move JTransforms dependency over to datavec-data-audio, where it is used

### DIFF
--- a/datavec-data/datavec-data-audio/pom.xml
+++ b/datavec-data/datavec-data-audio/pom.xml
@@ -50,6 +50,13 @@
             <version>${javacv.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.wendykierp</groupId>
+            <artifactId>JTransforms</artifactId>
+            <version>${jtransforms.version}</version>
+            <classifier>with-dependencies</classifier>
+        </dependency>
+
 <!-- Do not depend on FFmpeg by default due to licensing concerns. -->
 <!--
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -695,12 +695,6 @@
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-          <groupId>com.github.wendykierp</groupId>
-          <artifactId>JTransforms</artifactId>
-          <version>${jtransforms.version}</version>
-          <classifier>with-dependencies</classifier>
-      </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
As noted in https://github.com/deeplearning4j/DataVec/pull/508 the JTransforms dependency should be only used for the datavev-data-audio artifact, otherwise it ends up being pulled for everything - even datavec-api. 

This should address the immediate problem in https://github.com/deeplearning4j/deeplearning4j/issues/4718 where even without any direct datavec dependencies it ends up in the dependency tree.