### PR TITLE
Add PathMultiLabelGenerator for multi-class, multi-label image classification

### DIFF
--- a/datavec-api/pom.xml
+++ b/datavec-api/pom.xml
@@ -150,10 +150,16 @@
         </dependency>
 
         <dependency>
-         <groupId>com.tdunning</groupId>
-         <artifactId>t-digest</artifactId>
-         <version>${tdigest.version}</version>
-     </dependency>
+            <groupId>com.tdunning</groupId>
+            <artifactId>t-digest</artifactId>
+            <version>${tdigest.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>${eclipse.collections.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/datavec-api/src/main/java/org/datavec/api/io/labels/PathLabelGenerator.java
+++ b/datavec-api/src/main/java/org/datavec/api/io/labels/PathLabelGenerator.java
@@ -24,8 +24,13 @@ import java.net.URI;
 /**
  * PathLabelGenerator: interface to infer the label of a file directly from the path of a file<br>
  * Example: /negative/file17.csv -> class "0"; /positive/file116.csv -> class "1" etc.<br>
- * Though note that the output is a writable, hence it need not be numerical.
+ * Though note that the output is a writable, hence it need not be numerical.<br>
+ * <p>
+ * For use cases where multiple Writables are required (for example, networks with mixed classification/regression,
+ * or multiple output layers) use {@link PathMultiLabelGenerator} instead.
+ *
  * @author Alex Black
+ * @see PathMultiLabelGenerator
  */
 public interface PathLabelGenerator extends Serializable {
 
@@ -39,6 +44,7 @@ public interface PathLabelGenerator extends Serializable {
      * <br>
      * For regression use cases (or PathLabelGenerator classification instances that do their own label -> integer
      * assignment), this should return false.
+     *
      * @return whether label classes should be inferred
      */
     boolean inferLabelClasses();

--- a/datavec-api/src/main/java/org/datavec/api/io/labels/PathLabelGenerator.java
+++ b/datavec-api/src/main/java/org/datavec/api/io/labels/PathLabelGenerator.java
@@ -35,7 +35,7 @@ public interface PathLabelGenerator extends Serializable {
 
     /**
      * If true: infer the set of possible label classes, and convert these to integer indexes. If when true, the
-     * returned Writabels should be text writables.<br>
+     * returned Writables should be text writables.<br>
      * <br>
      * For regression use cases (or PathLabelGenerator classification instances that do their own label -> integer
      * assignment), this should return false.

--- a/datavec-api/src/main/java/org/datavec/api/io/labels/PathMultiLabelGenerator.java
+++ b/datavec-api/src/main/java/org/datavec/api/io/labels/PathMultiLabelGenerator.java
@@ -29,14 +29,24 @@ import java.util.List;
  * networks with multiple output layers)<br>
  * (b) Does <it>not</it> support inferring label classes<br>
  * <br>
- * Regarding (b) above, this means that the implementations of PathMultiLabelGenerator need to (for classification use
- * cases) do label to integer index assignment to one-hot arrays. In practice, this means if you have 3 classes {A,B,C}
- * you should return [1,0,0], [0,1,0] or [0,0,1] NDArrayWritables for the classes A, B and C respectively.<br>
- * Comparatively, PathLabelGenerator can return a Text writable with the label (i.e., "class_3" or "cat") whereas
- * PathMultiLabelGenerator must return Writables of one of the following types:
+ * Regarding (b) above, this means that the implementations of PathMultiLabelGenerator typically need to (for classification
+ * use cases) do one of two things (either will work, though down-stream usage of these arrays can vary slightly):
+ * (a) Perform label to integer index assignment (i.e., return an IntWritable(0) for A, if you have 3 classes {A,B,C})
+ * (b) Create a one-hot NDArrayWritable. For 3 classes {A,B,C} you should return a [1,0,0], [0,1,0] or [0,0,1] NDArrayWritable<br>
+ * Comparatively, PathLabelGenerator can return a Text writable with the label (i.e., "class_3" or "cat") for classification.<br>
+ * <br>
+ * More generally, PathMultiLabelGenerator must return Writables of one of the following types:
  * {@link org.datavec.api.writable.DoubleWritable}, {@link org.datavec.api.writable.FloatWritable},
  * {@link org.datavec.api.writable.IntWritable}, {@link org.datavec.api.writable.LongWritable} or
- * {@link org.datavec.api.writable.NDArrayWritable}
+ * {@link org.datavec.api.writable.NDArrayWritable}.<br>
+ * NDArrayWritable is used for classification (via one-hot NDArrayWritable) or multi-output regression (where all values
+ * are grouped together into a single array/writable) - whereas the others (double/float/int/long writables) are
+ * typically used for single output regression cases, or (IntWritable) for classification where downstream classes (notably
+ * DL4J's RecordReader(Multi)DataSetIterator) will convert the integer index (IntWritable) to a one-hot array ready for
+ * training.<br>
+ * <br>
+ * In principle, you can also return time series (3d - shape [1,size,seqLength]) or images (4d - shape
+ * [1,channels,height,width]) as a "label" for a given input image.
  *
  * @author Alex Black
  * @see PathLabelGenerator

--- a/datavec-api/src/main/java/org/datavec/api/io/labels/PathMultiLabelGenerator.java
+++ b/datavec-api/src/main/java/org/datavec/api/io/labels/PathMultiLabelGenerator.java
@@ -1,5 +1,5 @@
 /*
- *  * Copyright 2017 Skymind, Inc.
+ *  * Copyright 2018 Skymind, Inc.
  *  *
  *  *    Licensed under the Apache License, Version 2.0 (the "License");
  *  *    you may not use this file except in compliance with the License.
@@ -26,17 +26,20 @@ import java.util.List;
  * PathMultiLabelGenerator: interface to infer the label(s) of a file directly from the URI/path<br>
  * Similar to {@link PathLabelGenerator}, with 2 main differences:<br>
  * (a) Can be used for multi-label, multi-class classification (i.e., return *multiple* NDArray writables, for use in
- *     networks with multiple output layers)<br>
+ * networks with multiple output layers)<br>
  * (b) Does <it>not</it> support inferring label classes<br>
  * <br>
- * Regarding (b) above, this means that the implementations of PathMultiLabelGenerator need to do label to integer index
- * assignment for class labels. Comparatively, PathLabelGenerator can return a Text writable with the label (i.e.,
- * "class_3" or "cat") whereas PathMultiLabelGenerator must return Writables of one of the following types:
+ * Regarding (b) above, this means that the implementations of PathMultiLabelGenerator need to (for classification use
+ * cases) do label to integer index assignment to one-hot arrays. In practice, this means if you have 3 classes {A,B,C}
+ * you should return [1,0,0], [0,1,0] or [0,0,1] NDArrayWritables for the classes A, B and C respectively.<br>
+ * Comparatively, PathLabelGenerator can return a Text writable with the label (i.e., "class_3" or "cat") whereas
+ * PathMultiLabelGenerator must return Writables of one of the following types:
  * {@link org.datavec.api.writable.DoubleWritable}, {@link org.datavec.api.writable.FloatWritable},
  * {@link org.datavec.api.writable.IntWritable}, {@link org.datavec.api.writable.LongWritable} or
  * {@link org.datavec.api.writable.NDArrayWritable}
  *
  * @author Alex Black
+ * @see PathLabelGenerator
  */
 public interface PathMultiLabelGenerator extends Serializable {
 

--- a/datavec-api/src/main/java/org/datavec/api/io/labels/PathMultiLabelGenerator.java
+++ b/datavec-api/src/main/java/org/datavec/api/io/labels/PathMultiLabelGenerator.java
@@ -1,0 +1,49 @@
+/*
+ *  * Copyright 2017 Skymind, Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ */
+
+package org.datavec.api.io.labels;
+
+import org.datavec.api.writable.Writable;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * PathMultiLabelGenerator: interface to infer the label(s) of a file directly from the URI/path<br>
+ * Similar to {@link PathLabelGenerator}, with 2 main differences:<br>
+ * (a) Can be used for multi-label, multi-class classification (i.e., return *multiple* NDArray writables, for use in
+ *     networks with multiple output layers)<br>
+ * (b) Does <it>not</it> support inferring label classes<br>
+ * <br>
+ * Regarding (b) above, this means that the implementations of PathMultiLabelGenerator need to do label to integer index
+ * assignment for class labels. Comparatively, PathLabelGenerator can return a Text writable with the label (i.e.,
+ * "class_3" or "cat") whereas PathMultiLabelGenerator must return Writables of one of the following types:
+ * {@link org.datavec.api.writable.DoubleWritable}, {@link org.datavec.api.writable.FloatWritable},
+ * {@link org.datavec.api.writable.IntWritable}, {@link org.datavec.api.writable.LongWritable} or
+ * {@link org.datavec.api.writable.NDArrayWritable}
+ *
+ * @author Alex Black
+ */
+public interface PathMultiLabelGenerator extends Serializable {
+
+    /**
+     * @param uriPath The file or URI path to get the label for
+     * @return A list of labels for the specified URI/path
+     */
+    List<Writable> getLabels(String uriPath);
+
+}

--- a/datavec-api/src/main/java/org/datavec/api/util/ndarray/RecordConverter.java
+++ b/datavec-api/src/main/java/org/datavec/api/util/ndarray/RecordConverter.java
@@ -16,6 +16,9 @@
 
 package org.datavec.api.util.ndarray;
 
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import lombok.NonNull;
 import org.datavec.api.timeseries.util.TimeSeriesWritableUtils;
 import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.IntWritable;
@@ -136,7 +139,62 @@ public class RecordConverter {
         return arr;
     }
 
+    /**
+     * Convert a record to an INDArray, for use in minibatch training. That is, for an input record of length N, the output
+     * array has dimension 0 of size N (i.e., suitable for minibatch training in DL4J, for example).<br>
+     * The input list of writables must all be the same type (i.e., all NDArrayWritables or all non-array writables such
+     * as DoubleWritable etc).<br>
+     * Note that for NDArrayWritables, they must have leading dimension 1, and all other dimensions must match. <br>
+     * For example, row vectors are valid NDArrayWritables, as are 3d (usually time series) with shape [1, x, y], or
+     * 4d (usually images) with shape [1, x, y, z] where (x,y,z) are the same for all inputs
+     * @param l the records to convert
+     * @return the array
+     * @see #toArray(Collection) for the "single example concatenation" version of this method
+     */
+    public static INDArray toMinibatchArray(@NonNull List<? extends Writable> l) {
+        Preconditions.checkArgument(l.size() > 0, "Cannot convert empty list");
 
+        //Edge case: single NDArrayWritable
+        if(l.size() == 1 && l.get(0) instanceof NDArrayWritable){
+            return ((NDArrayWritable) l.get(0)).get();
+        }
+
+        //Check: all NDArrayWritable or all non-writable
+        List<INDArray> toConcat = null;
+        DoubleArrayList list = null;
+        for (Writable w : l) {
+            if (w instanceof NDArrayWritable) {
+                INDArray a = ((NDArrayWritable) w).get();
+                if (a.size(0) != 1) {
+                    throw new UnsupportedOperationException("NDArrayWritable must have leading dimension 1 for this" +
+                            "method. Received array with shape: " + Arrays.toString(a.shape()));
+                }
+                if(toConcat == null){
+                    toConcat = new ArrayList<>();
+                }
+                toConcat.add(a);
+            } else {
+                //Assume all others are single value
+                if(list == null){
+                    list = new DoubleArrayList();
+                }
+                list.add(w.toDouble());
+            }
+        }
+
+
+        if(toConcat != null && list != null){
+            throw new IllegalStateException("Error converting writables: found both NDArrayWritable and single value" +
+                    " (DoubleWritable etc) in the one list. All writables must be NDArrayWritables or " +
+                    "single value writables only for this method");
+        }
+
+        if(toConcat != null){
+            return Nd4j.concat(0, toConcat.toArray(new INDArray[toConcat.size()]));
+        } else {
+            return Nd4j.create(list.toDoubleArray(), new int[]{list.size(), 1});
+        }
+    }
 
     /**
      * Convert an ndarray to a record

--- a/datavec-api/src/main/java/org/datavec/api/util/ndarray/RecordConverter.java
+++ b/datavec-api/src/main/java/org/datavec/api/util/ndarray/RecordConverter.java
@@ -17,13 +17,13 @@
 package org.datavec.api.util.ndarray;
 
 import com.google.common.base.Preconditions;
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import lombok.NonNull;
 import org.datavec.api.timeseries.util.TimeSeriesWritableUtils;
 import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.IntWritable;
 import org.datavec.api.writable.NDArrayWritable;
 import org.datavec.api.writable.Writable;
+import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
@@ -192,7 +192,7 @@ public class RecordConverter {
         if(toConcat != null){
             return Nd4j.concat(0, toConcat.toArray(new INDArray[toConcat.size()]));
         } else {
-            return Nd4j.create(list.toDoubleArray(), new int[]{list.size(), 1});
+            return Nd4j.create(list.toArray(), new int[]{list.size(), 1});
         }
     }
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -21,7 +21,6 @@ import org.datavec.api.conf.Configuration;
 import org.datavec.api.io.labels.PathLabelGenerator;
 import org.datavec.api.io.labels.PathMultiLabelGenerator;
 import org.datavec.api.records.Record;
-import org.datavec.api.records.converter.RecordReaderConverter;
 import org.datavec.api.records.metadata.RecordMetaData;
 import org.datavec.api.records.metadata.RecordMetaDataURI;
 import org.datavec.api.records.reader.BaseRecordReader;

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/ImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/ImageRecordReader.java
@@ -18,6 +18,7 @@ package org.datavec.image.recordreader;
 
 
 import org.datavec.api.io.labels.PathLabelGenerator;
+import org.datavec.api.io.labels.PathMultiLabelGenerator;
 import org.datavec.image.transform.ImageTransform;
 
 /**
@@ -40,6 +41,11 @@ public class ImageRecordReader extends BaseImageRecordReader {
 
     /** Loads images with given height, width, and channels, appending labels returned by the generator. */
     public ImageRecordReader(int height, int width, int channels, PathLabelGenerator labelGenerator) {
+        super(height, width, channels, labelGenerator);
+    }
+
+    /** Loads images with given height, width, and channels, appending labels returned by the generator. */
+    public ImageRecordReader(int height, int width, int channels, PathMultiLabelGenerator labelGenerator) {
         super(height, width, channels, labelGenerator);
     }
 

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
@@ -71,7 +71,7 @@ public class ObjectDetectionRecordReader extends BaseImageRecordReader {
      * @param labelProvider ImageObjectLabelProvider - used to look up which objects are in each image
      */
     public ObjectDetectionRecordReader(int height, int width, int channels, int gridH, int gridW, ImageObjectLabelProvider labelProvider) {
-        super(height, width, channels, null);
+        super(height, width, channels, null, null);
         this.gridW = gridW;
         this.gridH = gridH;
         this.labelProvider = labelProvider;
@@ -91,7 +91,7 @@ public class ObjectDetectionRecordReader extends BaseImageRecordReader {
      */
     public ObjectDetectionRecordReader(int height, int width, int channels, int gridH, int gridW,
             ImageObjectLabelProvider labelProvider, ImageTransform imageTransform) {
-        super(height, width, channels, null);
+        super(height, width, channels, null, null);
         this.gridW = gridW;
         this.gridH = gridH;
         this.labelProvider = labelProvider;

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/recordreader/TestImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/recordreader/TestImageRecordReader.java
@@ -16,8 +16,10 @@
 
 package org.datavec.image.recordreader;
 
+import org.apache.commons.io.FilenameUtils;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.io.labels.PathLabelGenerator;
+import org.datavec.api.io.labels.PathMultiLabelGenerator;
 import org.datavec.api.records.Record;
 import org.datavec.api.records.metadata.RecordMetaData;
 import org.datavec.api.split.CollectionInputSplit;
@@ -257,4 +259,119 @@ public class TestImageRecordReader {
                 throw new RuntimeException(filename);
         }
     }
+
+
+    @Test
+    public void testImageRecordReaderPathMultiLabelGenerator() throws Exception {
+        //Assumption: 2 multi-class (one hot) classification labels: 2 and 3 classes respectively
+        // PLUS single value (Writable) regression label
+
+        PathMultiLabelGenerator multiLabelGen = new TestPathMultiLabelGenerator();
+
+        ImageRecordReader rr = new ImageRecordReader(28, 28, 3, multiLabelGen);
+
+        File rootDir = new ClassPathResource("/testimages/").getFile();
+        FileSplit fs = new FileSplit(rootDir);
+        rr.initialize(fs);
+        URI[] arr = fs.locations();
+
+        assertTrue(rr.getLabels() == null || rr.getLabels().isEmpty());
+
+        List<List<Writable>> expLabels = new ArrayList<>();
+        for(URI u : arr){
+            String path = u.getPath();
+            expLabels.add(testMultiLabel(path.substring(path.length()-5, path.length())));
+        }
+
+        int count = 0;
+        while(rr.hasNext()){
+            List<Writable> l = rr.next();
+            assertEquals(4, l.size());
+            for( int i=0; i<3; i++ ){
+                assertEquals(expLabels.get(count).get(i), l.get(i+1));
+            }
+            count++;
+        }
+        assertEquals(6, count);
+
+        //Test batch ops:
+        rr.reset();
+        List<Writable> b1 = rr.next(3);
+        List<Writable> b2 = rr.next(3);
+        assertFalse(rr.hasNext());
+        assertEquals(4, b1.size());
+        assertEquals(4, b2.size());
+
+        NDArrayWritable l1a = new NDArrayWritable(Nd4j.vstack(
+                ((NDArrayWritable)expLabels.get(0).get(0)).get(),
+                ((NDArrayWritable)expLabels.get(1).get(0)).get(),
+                ((NDArrayWritable)expLabels.get(2).get(0)).get()));
+        NDArrayWritable l1b = new NDArrayWritable(Nd4j.vstack(
+                ((NDArrayWritable)expLabels.get(0).get(1)).get(),
+                ((NDArrayWritable)expLabels.get(1).get(1)).get(),
+                ((NDArrayWritable)expLabels.get(2).get(1)).get()));
+        NDArrayWritable l1c = new NDArrayWritable(Nd4j.create(new double[]{
+                expLabels.get(0).get(2).toDouble(),
+                expLabels.get(1).get(2).toDouble(),
+                expLabels.get(2).get(2).toDouble()}));
+
+
+        NDArrayWritable l2a = new NDArrayWritable(Nd4j.vstack(
+                ((NDArrayWritable)expLabels.get(3).get(0)).get(),
+                ((NDArrayWritable)expLabels.get(4).get(0)).get(),
+                ((NDArrayWritable)expLabels.get(5).get(0)).get()));
+        NDArrayWritable l2b = new NDArrayWritable(Nd4j.vstack(
+                ((NDArrayWritable)expLabels.get(3).get(1)).get(),
+                ((NDArrayWritable)expLabels.get(4).get(1)).get(),
+                ((NDArrayWritable)expLabels.get(5).get(1)).get()));
+        NDArrayWritable l2c = new NDArrayWritable(Nd4j.create(new double[]{
+                expLabels.get(3).get(2).toDouble(),
+                expLabels.get(4).get(2).toDouble(),
+                expLabels.get(5).get(2).toDouble()}));
+
+
+
+        assertEquals(l1a, b1.get(1));
+        assertEquals(l1b, b1.get(2));
+        assertEquals(l1c, b1.get(3));
+
+        assertEquals(l2a, b2.get(1));
+        assertEquals(l2b, b2.get(2));
+        assertEquals(l2c, b2.get(3));
+    }
+
+    private static class TestPathMultiLabelGenerator implements PathMultiLabelGenerator {
+
+        @Override
+        public List<Writable> getLabels(String uriPath) {
+            String filename = uriPath.substring(uriPath.length()-5);
+            return testMultiLabel(filename);
+        }
+    }
+
+    private static List<Writable> testMultiLabel(String filename){
+        switch(filename){
+            case "0.jpg":
+                return Arrays.<Writable>asList(new NDArrayWritable(Nd4j.create(new double[]{1,0})),
+                        new NDArrayWritable(Nd4j.create(new double[]{1,0,0})), new DoubleWritable(0.0));
+            case "1.png":
+                return Arrays.<Writable>asList(new NDArrayWritable(Nd4j.create(new double[]{1,0})),
+                        new NDArrayWritable(Nd4j.create(new double[]{0,1,0})), new DoubleWritable(1.0));
+            case "2.jpg":
+                return Arrays.<Writable>asList(new NDArrayWritable(Nd4j.create(new double[]{1,0})),
+                        new NDArrayWritable(Nd4j.create(new double[]{0,0,1})), new DoubleWritable(2.0));
+            case "A.jpg":
+                return Arrays.<Writable>asList(new NDArrayWritable(Nd4j.create(new double[]{0,1})),
+                        new NDArrayWritable(Nd4j.create(new double[]{1,0,0})), new DoubleWritable(3.0));
+            case "B.png":
+                return Arrays.<Writable>asList(new NDArrayWritable(Nd4j.create(new double[]{0,1})),
+                        new NDArrayWritable(Nd4j.create(new double[]{0,1,0})), new DoubleWritable(4.0));
+            case "C.jpg":
+                return Arrays.<Writable>asList(new NDArrayWritable(Nd4j.create(new double[]{0,1})),
+                        new NDArrayWritable(Nd4j.create(new double[]{0,0,1})), new DoubleWritable(5.0));
+            default:
+                throw new RuntimeException(filename);
+        }
+    }
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <opencsv.version>2.3</opencsv.version>
         <tdigest.version>3.2</tdigest.version>
         <jtransforms.version>3.1</jtransforms.version>
+        <eclipse.collections.version>9.1.0</eclipse.collections.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Currently: binary multi-label data pipelines for image classification are easy enough via PathLabelGenerator. But multi-class, multi-label is not user friendly at present. This PR aims to rectify that by introducing PathMultiLabelGenerator.