### PR TITLE
safer conversions on BytesWritable asNd4jBuffer

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/writable/BytesWritable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/BytesWritable.java
@@ -11,6 +11,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -65,9 +66,25 @@ public class BytesWritable extends ArrayWritable {
      * @return the equivalent nd4j data buffer
      */
     public DataBuffer asNd4jBuffer(DataBuffer.Type type,int elementSize) {
-        ByteBuffer direct = ByteBuffer.allocateDirect(content.length);
-        direct.put(getContent());
-        return Nd4j.createBuffer(direct,type,content.length / elementSize);
+        int length = content.length / elementSize;
+        DataBuffer ret = Nd4j.createBuffer(ByteBuffer.allocateDirect(content.length),type,length,0);
+        for(int i = 0; i < length; i++) {
+            switch(type) {
+                case DOUBLE:
+                    ret.put(i,getDouble(i));
+                    break;
+                case INT:
+                    ret.put(i,getInt(i));
+                    break;
+                case FLOAT:
+                    ret.put(i,getFloat(i));
+                   break;
+                case LONG:
+                    ret.put(i,getLong(i));
+                    break;
+            }
+        }
+        return ret;
     }
 
     @Override

--- a/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -37,9 +37,10 @@ public class WritableTest {
         ByteBuffer wrapped = ByteBuffer.wrap(doubleWrite);
         wrapped.putDouble(1.0);
         wrapped.putDouble(2.0);
+        wrapped.rewind();
         BytesWritable byteWritable = new BytesWritable(doubleWrite);
         assertEquals(2,byteWritable.getDouble(1),1e-1);
-        org.nd4j.linalg.api.buffer.DataBuffer dataBuffer = Nd4j.createBuffer(new double[] {1,2});
+        DataBuffer dataBuffer = Nd4j.createBuffer(new double[] {1,2});
         assertEquals(dataBuffer,byteWritable.asNd4jBuffer(DataBuffer.Type.DOUBLE,8));
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Type conversions between 2 buffers are error prone. This is a more agnostic way of doing it that works across OSes.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
