### PR TITLE
draft of bootstrapping input splits, also clean up input split interface

### DIFF
--- a/datavec-api/src/main/java/org/datavec/api/formats/output/impl/CSVOutputFormat.java
+++ b/datavec-api/src/main/java/org/datavec/api/formats/output/impl/CSVOutputFormat.java
@@ -35,10 +35,6 @@ public class CSVOutputFormat implements OutputFormat {
     @Override
     public RecordWriter createWriter(Configuration conf) throws DataVecException {
         String outputPath = conf.get(OutputFormat.OUTPUT_PATH, ".");
-        try {
-            return new CSVRecordWriter(new File(outputPath));
-        } catch (FileNotFoundException e) {
-            throw new DataVecException(e);
-        }
+        return new CSVRecordWriter();
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/formats/output/impl/LineOutputFormat.java
+++ b/datavec-api/src/main/java/org/datavec/api/formats/output/impl/LineOutputFormat.java
@@ -34,10 +34,6 @@ public class LineOutputFormat implements OutputFormat {
     @Override
     public RecordWriter createWriter(Configuration conf) throws DataVecException {
         String outputPath = conf.get(OutputFormat.OUTPUT_PATH, ".");
-        try {
-            return new LineRecordWriter(new File(outputPath));
-        } catch (FileNotFoundException e) {
-            throw new DataVecException(e);
-        }
+        return new LineRecordWriter();
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/formats/output/impl/SVMLightOutputFormat.java
+++ b/datavec-api/src/main/java/org/datavec/api/formats/output/impl/SVMLightOutputFormat.java
@@ -35,7 +35,7 @@ public class SVMLightOutputFormat implements OutputFormat {
         String outputPath = conf.get(OutputFormat.OUTPUT_PATH, ".");
         try {
             //return new LineRecordWriter(new File(outputPath));
-            return new SVMLightRecordWriter(new File(outputPath));
+            return new SVMLightRecordWriter();
         } catch (Exception e) {
             throw new DataVecException(e);
         }

--- a/datavec-api/src/main/java/org/datavec/api/records/mapper/RecordMapper.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/mapper/RecordMapper.java
@@ -1,5 +1,6 @@
 package org.datavec.api.records.mapper;
 
+import lombok.Builder;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.records.writer.RecordWriter;
@@ -9,29 +10,86 @@ import org.datavec.api.writable.Writable;
 
 import java.util.List;
 
+/**
+ * This takes data from a specified {@link RecordReader}
+ * and writes the data out with the specified {@link RecordWriter}.
+ *
+ * The setup is as follows:
+ *
+ * Specify a {@link RecordReader} as the data source
+ * Specify a {@link RecordWriter} as the destination.
+ *
+ * When setting up the locations, use 2 different {@link InputSplit}
+ * calling {@link RecordWriter#initialize(InputSplit, Partitioner)}
+ * and {@link RecordReader#initialize(InputSplit)}
+ * respectively to configure the locations of where the data will be
+ * read from and written to.
+ *
+ * When writing the data, you need to specify a link {@link Partitioner} to
+ * determine how to slice up the data being written (say in to number of lines per record per file
+ * per {@link org.datavec.api.split.partition.NumberOfRecordsPartitioner} among other implementations.
+ *
+ * Finally, you may specify a batch size for batch read and write if the record reader and writer support it.
+ *
+ * See {@link #copy()} for more information here.
+ */
+@Builder
 public class RecordMapper {
+
     private RecordReader recordReader;
     private RecordWriter recordWriter;
     private InputSplit inputUrl;
     private InputSplit outputUrl;
-    private Configuration configuration;
+    @Builder.Default
+    private Configuration configuration = new Configuration();
     private Partitioner partitioner;
+    private int batchSize;
 
+    /**
+     * Copy the {@link RecordReader}
+     * data using the {@link RecordWriter}.
+     * Note that unless batch is supported by
+     * both the {@link RecordReader} and {@link RecordWriter}
+     * then writes will happen one at a time.
+     * You can see if batch is enabled via {@link RecordReader#batchesSupported()}
+     * and {@link RecordWriter#supportsBatch()} respectively.
+     * @throws Exception
+     */
     public void copy() throws Exception {
         recordReader.initialize(configuration,inputUrl);
         partitioner.init(configuration,outputUrl);
         recordWriter.initialize(configuration,outputUrl,partitioner);
 
 
-        while(recordReader.hasNext()) {
-            List<Writable> next = recordReader.next();
-            recordWriter.write(next);
-            //update records written
-            partitioner.updatePartitionInfo(1);
-            if(partitioner.needsNewPartition()) {
-                partitioner.openNewStream();
+        if(batchSize > 0 && recordReader.batchesSupported() && recordWriter.supportsBatch()) {
+            while(recordReader.hasNext()) {
+                List<List<Writable>> next = recordReader.next(batchSize);
+                //update records written
+                partitioner.updatePartitionInfo(recordWriter.writeBatch(next));
+                if(recordReader.hasNext() && partitioner.needsNewPartition()) {
+                    partitioner.currentOutputStream().flush();
+                    partitioner.currentOutputStream().close();
+                    partitioner.openNewStream();
+                }
+            }
+
+            partitioner.currentOutputStream().flush();
+            partitioner.currentOutputStream().close();
+            recordReader.close();
+            recordWriter.close();
+        }
+
+        else {
+            while(recordReader.hasNext()) {
+                List<Writable> next = recordReader.next();
+                //update records written
+                partitioner.updatePartitionInfo(recordWriter.write(next));
+                if(partitioner.needsNewPartition()) {
+                    partitioner.openNewStream();
+                }
             }
         }
+
     }
 
 

--- a/datavec-api/src/main/java/org/datavec/api/records/mapper/RecordMapper.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/mapper/RecordMapper.java
@@ -1,0 +1,38 @@
+package org.datavec.api.records.mapper;
+
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.records.reader.RecordReader;
+import org.datavec.api.records.writer.RecordWriter;
+import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.Partitioner;
+import org.datavec.api.writable.Writable;
+
+import java.util.List;
+
+public class RecordMapper {
+    private RecordReader recordReader;
+    private RecordWriter recordWriter;
+    private InputSplit inputUrl;
+    private InputSplit outputUrl;
+    private Configuration configuration;
+    private Partitioner partitioner;
+
+    public void copy() throws Exception {
+        recordReader.initialize(configuration,inputUrl);
+        partitioner.init(configuration,outputUrl);
+        recordWriter.initialize(configuration,outputUrl,partitioner);
+
+
+        while(recordReader.hasNext()) {
+            List<Writable> next = recordReader.next();
+            recordWriter.write(next);
+            //update records written
+            partitioner.updatePartitionInfo(1);
+            if(partitioner.needsNewPartition()) {
+                partitioner.openNewStream();
+            }
+        }
+    }
+
+
+}

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/BaseRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/BaseRecordReader.java
@@ -61,7 +61,7 @@ public abstract class BaseRecordReader implements RecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/RecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/RecordReader.java
@@ -39,10 +39,10 @@ import java.util.List;
  */
 public interface RecordReader extends Closeable, Serializable, Configurable {
 
-    public final static String NAME_SPACE = RecordReader.class.getName();
+    String NAME_SPACE = RecordReader.class.getName();
 
-    public final static String APPEND_LABEL = NAME_SPACE + ".appendlabel";
-    public final static String LABELS = NAME_SPACE + ".labels";
+    String APPEND_LABEL = NAME_SPACE + ".appendlabel";
+    String LABELS = NAME_SPACE + ".labels";
 
     /**
      * Called once at initialization.
@@ -76,7 +76,7 @@ public interface RecordReader extends Closeable, Serializable, Configurable {
      * @param num
      * @return
      */
-    List<Writable> next(int num);
+    List<List<Writable>> next(int num);
 
     /**
      * Get the next record

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/FileRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/FileRecordReader.java
@@ -148,6 +148,16 @@ public class FileRecordReader extends BaseRecordReader {
     }
 
     @Override
+    public List<List<Writable>> next(int num) {
+        List<List<Writable>> ret = new ArrayList<>(num);
+        int numBatches = 0;
+        while (hasNext() && numBatches < num) {
+            ret.add(next());
+        }
+
+        return ret;
+    }
+    @Override
     public void reset() {
         if (inputSplit == null)
             throw new UnsupportedOperationException("Cannot reset without first initializing");
@@ -190,7 +200,7 @@ public class FileRecordReader extends BaseRecordReader {
         List<Writable> ret = loadFromFile(next);
 
         return new org.datavec.api.records.impl.Record(ret,
-                        new RecordMetaDataURI(next.toURI(), FileRecordReader.class));
+                new RecordMetaDataURI(next.toURI(), FileRecordReader.class));
     }
 
     protected File nextFile() {

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRecordReader.java
@@ -144,8 +144,24 @@ public class CSVRecordReader extends LineRecordReader {
     }
 
     @Override
+    public boolean batchesSupported() {
+        return true;
+    }
+
+    @Override
     public boolean hasNext() {
         return skipLines() && super.hasNext();
+    }
+
+    @Override
+    public List<List<Writable>> next(int num) {
+        List<List<Writable>> ret = new ArrayList<>(num);
+        int recordsRead = 0;
+        while(hasNext() && recordsRead < num) {
+            ret.add(next());
+        }
+
+        return ret;
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRegexRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVRegexRecordReader.java
@@ -25,7 +25,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * A CSVRecordReader that can split each column into additional columns using regexs.
+ * A CSVRecordReader that can split
+ * each column into additional columns using regexs.
  *
  * @author saudet
  */

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemoryRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemoryRecordReader.java
@@ -65,7 +65,7 @@ public class InMemoryRecordReader implements RecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemorySequenceRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/inmemory/InMemorySequenceRecordReader.java
@@ -70,7 +70,7 @@ public class InMemorySequenceRecordReader implements SequenceRecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
@@ -60,7 +60,7 @@ public class TransformProcessRecordReader implements RecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessSequenceRecordReader.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessSequenceRecordReader.java
@@ -65,7 +65,7 @@ public class TransformProcessSequenceRecordReader implements SequenceRecordReade
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/RecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/RecordWriter.java
@@ -20,6 +20,7 @@ package org.datavec.api.records.writer;
 import org.datavec.api.conf.Configurable;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.split.partition.Partitioner;
 import org.datavec.api.writable.Writable;
 
@@ -35,6 +36,12 @@ public interface RecordWriter extends Closeable, Configurable {
     String APPEND = "org.datavec.api.record.writer.append";
 
 
+    /**
+     * Returns true if this record writer
+     * supports efficient batch writing using {@link #writeBatch(List)}
+     * @return
+     */
+    boolean supportsBatch();
     /**
      * Initialize a record writer with the given input split
      * @param inputSplit the input split to initialize with
@@ -55,14 +62,14 @@ public interface RecordWriter extends Closeable, Configurable {
      * Write a record
      * @param record the record to write
      */
-    void write(List<Writable> record) throws IOException;
+    PartitionMetaData write(List<Writable> record) throws IOException;
 
 
     /**
      * Write a batch of records
      * @param batch the batch to write
      */
-    void writeBatch(List<List<Writable>> batch) throws IOException;
+    PartitionMetaData writeBatch(List<List<Writable>> batch) throws IOException;
 
 
     /**

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/RecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/RecordWriter.java
@@ -18,6 +18,8 @@ package org.datavec.api.records.writer;
 
 
 import org.datavec.api.conf.Configurable;
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.split.InputSplit;
 import org.datavec.api.writable.Writable;
 
 import java.io.Closeable;
@@ -31,11 +33,33 @@ import java.util.List;
 public interface RecordWriter extends Closeable, Configurable {
     String APPEND = "org.datavec.api.record.writer.append";
 
+
+    /**
+     * Initialize a record writer with the given input split
+     * @param inputSplit the input split to initialize with
+     */
+    void initialize(InputSplit inputSplit) throws Exception;
+
+    /**
+     * Initialize the record reader with the given configuration
+     * and {@link InputSplit}
+     * @param configuration the configuration to iniailize with
+     * @param split the split to use
+     */
+    void initialize(Configuration configuration, InputSplit split) throws Exception;
+
     /**
      * Write a record
      * @param record the record to write
      */
     void write(List<Writable> record) throws IOException;
+
+
+    /**
+     * Write a batch of records
+     * @param batch the batch to write
+     */
+    void writeBatch(List<List<Writable>> batch) throws IOException;
 
 
     /**

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/RecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/RecordWriter.java
@@ -20,6 +20,7 @@ package org.datavec.api.records.writer;
 import org.datavec.api.conf.Configurable;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.Partitioner;
 import org.datavec.api.writable.Writable;
 
 import java.io.Closeable;
@@ -37,16 +38,18 @@ public interface RecordWriter extends Closeable, Configurable {
     /**
      * Initialize a record writer with the given input split
      * @param inputSplit the input split to initialize with
+     * @param partitioner
      */
-    void initialize(InputSplit inputSplit) throws Exception;
+    void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception;
 
     /**
      * Initialize the record reader with the given configuration
      * and {@link InputSplit}
      * @param configuration the configuration to iniailize with
      * @param split the split to use
+     * @param partitioner
      */
-    void initialize(Configuration configuration, InputSplit split) throws Exception;
+    void initialize(Configuration configuration, InputSplit split, Partitioner partitioner) throws Exception;
 
     /**
      * Write a record

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/SequenceRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/SequenceRecordWriter.java
@@ -19,6 +19,7 @@ package org.datavec.api.records.writer;
 
 
 import org.datavec.api.conf.Configurable;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.writable.Writable;
 
 import java.io.Closeable;
@@ -37,7 +38,7 @@ public interface SequenceRecordWriter extends Closeable, Configurable {
      * Write a record
      * @param sequence the record to write
      */
-    void write(List<List<Writable>> sequence) throws IOException;
+    PartitionMetaData write(List<List<Writable>> sequence) throws IOException;
 
 
     /**

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/FileRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/FileRecordWriter.java
@@ -57,43 +57,20 @@ public class FileRecordWriter implements RecordWriter {
 
     public FileRecordWriter() {}
 
-    public FileRecordWriter(File path) throws FileNotFoundException {
-        this(path, false, DEFAULT_CHARSET);
-    }
 
-
-    public FileRecordWriter(File path, boolean append) throws FileNotFoundException {
-        this(path, append, DEFAULT_CHARSET);
-    }
-
-    public FileRecordWriter(File path, boolean append, Charset encoding) throws FileNotFoundException {
-        this.writeTo = path;
-        this.append = append;
-        this.encoding = encoding;
-        out = new DataOutputStream(new FileOutputStream(writeTo, append));
-    }
-
-
-    /**
-     * Initialized based on configuration
-     * Set the following attributes in the conf:
-     *
-     * @param conf the configuration to use
-     * @throws FileNotFoundException
-     */
-    public FileRecordWriter(Configuration conf) throws FileNotFoundException {
-        setConf(conf);
-    }
 
     @Override
     public void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception {
-        out = new DataOutputStream(inputSplit.openOutputStreamFor(writeTo.getAbsolutePath()));
+        partitioner.init(inputSplit);
+        out = new DataOutputStream(partitioner.currentOutputStream());
         this.partitioner = partitioner;
+
     }
 
     @Override
     public void initialize(Configuration configuration, InputSplit split, Partitioner partitioner) throws Exception {
         setConf(configuration);
+        partitioner.init(configuration,split);
         initialize(split, partitioner);
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/FileRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/FileRecordWriter.java
@@ -20,6 +20,7 @@ package org.datavec.api.records.writer.impl;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.RecordWriter;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.Partitioner;
 import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
 
@@ -49,6 +50,8 @@ public class FileRecordWriter implements RecordWriter {
     public final static String PATH = "org.datavec.api.records.writer.path";
 
     protected Charset encoding = DEFAULT_CHARSET;
+
+    protected Partitioner partitioner;
 
     protected Configuration conf;
 
@@ -83,14 +86,15 @@ public class FileRecordWriter implements RecordWriter {
     }
 
     @Override
-    public void initialize(InputSplit inputSplit) throws Exception {
+    public void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception {
         out = new DataOutputStream(inputSplit.openOutputStreamFor(writeTo.getAbsolutePath()));
+        this.partitioner = partitioner;
     }
 
     @Override
-    public void initialize(Configuration configuration, InputSplit split) throws Exception {
+    public void initialize(Configuration configuration, InputSplit split, Partitioner partitioner) throws Exception {
         setConf(configuration);
-        initialize(split);
+        initialize(split, partitioner);
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/LineRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/LineRecordWriter.java
@@ -17,12 +17,9 @@
 package org.datavec.api.records.writer.impl;
 
 
-import org.datavec.api.conf.Configuration;
 import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -33,17 +30,6 @@ import java.util.List;
 public class LineRecordWriter extends FileRecordWriter {
     public LineRecordWriter() {}
 
-    public LineRecordWriter(File path) throws FileNotFoundException {
-        super(path);
-    }
-
-    public LineRecordWriter(File path, boolean append) throws FileNotFoundException {
-        super(path, append);
-    }
-
-    public LineRecordWriter(Configuration conf) throws FileNotFoundException {
-        super(conf);
-    }
 
     @Override
     public void write(List<Writable> record) throws IOException {

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/LineRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/LineRecordWriter.java
@@ -17,6 +17,7 @@
 package org.datavec.api.records.writer.impl;
 
 
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
 
@@ -32,13 +33,15 @@ public class LineRecordWriter extends FileRecordWriter {
 
 
     @Override
-    public void write(List<Writable> record) throws IOException {
+    public PartitionMetaData write(List<Writable> record) throws IOException {
         if (!record.isEmpty()) {
             Text t = (Text) record.iterator().next();
             t.write(out);
             out.write(NEW_LINE.getBytes());
         }
 
+
+        return PartitionMetaData.builder().numRecordsUpdated(1).build();
 
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/csv/CSVRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/csv/CSVRecordWriter.java
@@ -61,6 +61,13 @@ public class CSVRecordWriter extends FileRecordWriter {
     }
 
     @Override
+    public void writeBatch(List<List<Writable>> batch) throws IOException {
+        for(List<Writable> record : batch) {
+            write(record);
+        }
+    }
+
+    @Override
     public void write(List<Writable> record) throws IOException {
         if (!record.isEmpty()) {
             //Add new line before appending lines rather than after (avoids newline after last line)

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/csv/CSVRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/csv/CSVRecordWriter.java
@@ -17,14 +17,10 @@
 package org.datavec.api.records.writer.impl.csv;
 
 
-import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.impl.FileRecordWriter;
 import org.datavec.api.writable.Writable;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.List;
 
 /**
@@ -42,23 +38,7 @@ public class CSVRecordWriter extends FileRecordWriter {
         delimBytes = DEFAULT_DELIMITER.getBytes(encoding);
     }
 
-    public CSVRecordWriter(File path) throws FileNotFoundException {
-        this(path, false, DEFAULT_CHARSET, DEFAULT_DELIMITER);
-    }
 
-    public CSVRecordWriter(File path, boolean append) throws FileNotFoundException {
-        this(path, append, DEFAULT_CHARSET, DEFAULT_DELIMITER);
-    }
-
-    public CSVRecordWriter(Configuration conf) throws FileNotFoundException {
-        super(conf);
-        delimBytes = DEFAULT_DELIMITER.getBytes(encoding);
-    }
-
-    public CSVRecordWriter(File path, boolean append, Charset encoding, String delimiter) throws FileNotFoundException {
-        super(path, append, encoding);
-        this.delimBytes = delimiter.getBytes(encoding);
-    }
 
     @Override
     public void writeBatch(List<List<Writable>> batch) throws IOException {

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/LibSvmRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/LibSvmRecordWriter.java
@@ -40,10 +40,4 @@ import java.io.FileNotFoundException;
  * @author dave@skymind.io
  */
 @Slf4j
-public class LibSvmRecordWriter extends SVMLightRecordWriter {
-    public LibSvmRecordWriter() {
-        super();
-    }
-
-
-}
+public class LibSvmRecordWriter extends SVMLightRecordWriter {}

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/LibSvmRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/LibSvmRecordWriter.java
@@ -45,21 +45,5 @@ public class LibSvmRecordWriter extends SVMLightRecordWriter {
         super();
     }
 
-    public LibSvmRecordWriter(File path) throws FileNotFoundException {
-        super(path);
-    }
 
-    public LibSvmRecordWriter(File path, boolean append) throws FileNotFoundException {
-        super(path, append);
-    }
-
-    public LibSvmRecordWriter(Configuration conf) throws FileNotFoundException {
-        super(conf);
-        setConf(conf);
-    }
-
-    @Override
-    public void setConf(Configuration conf) {
-        super.setConf(conf);
-    }
 }

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/MatlabRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/MatlabRecordWriter.java
@@ -17,12 +17,10 @@
 package org.datavec.api.records.writer.impl.misc;
 
 
-import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.impl.FileRecordWriter;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.writable.Writable;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -36,7 +34,7 @@ public class MatlabRecordWriter extends FileRecordWriter {
 
 
     @Override
-    public void write(List<Writable> record) throws IOException {
+    public PartitionMetaData write(List<Writable> record) throws IOException {
         StringBuilder result = new StringBuilder();
 
         int count = 0;
@@ -54,7 +52,7 @@ public class MatlabRecordWriter extends FileRecordWriter {
         out.write(result.toString().getBytes());
         out.write(NEW_LINE.getBytes());
 
-
+        return PartitionMetaData.builder().numRecordsUpdated(1).build();
 
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/MatlabRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/MatlabRecordWriter.java
@@ -34,17 +34,6 @@ import java.util.List;
 public class MatlabRecordWriter extends FileRecordWriter {
     public MatlabRecordWriter() {}
 
-    public MatlabRecordWriter(File path) throws FileNotFoundException {
-        super(path);
-    }
-
-    public MatlabRecordWriter(File path, boolean append) throws FileNotFoundException {
-        super(path, append);
-    }
-
-    public MatlabRecordWriter(Configuration conf) throws FileNotFoundException {
-        super(conf);
-    }
 
     @Override
     public void write(List<Writable> record) throws IOException {

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/SVMLightRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/SVMLightRecordWriter.java
@@ -86,18 +86,7 @@ public class SVMLightRecordWriter extends FileRecordWriter {
 
     public SVMLightRecordWriter() {}
 
-    public SVMLightRecordWriter(File path) throws FileNotFoundException {
-        super(path);
-    }
 
-    public SVMLightRecordWriter(File path, boolean append) throws FileNotFoundException {
-        super(path, append);
-    }
-
-    public SVMLightRecordWriter(Configuration conf) throws FileNotFoundException {
-        super(conf);
-        setConf(conf);
-    }
 
     /**
      * Set DataVec configuration

--- a/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/SVMLightRecordWriter.java
+++ b/datavec-api/src/main/java/org/datavec/api/records/writer/impl/misc/SVMLightRecordWriter.java
@@ -20,11 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.reader.impl.misc.SVMLightRecordReader;
 import org.datavec.api.records.writer.impl.FileRecordWriter;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.writable.ArrayWritable;
 import org.datavec.api.writable.Writable;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,7 +112,7 @@ public class SVMLightRecordWriter extends FileRecordWriter {
      * @throws IOException
      */
     @Override
-    public void write(List<Writable> record) throws IOException {
+    public PartitionMetaData write(List<Writable> record) throws IOException {
         if (!record.isEmpty()) {
             List<Writable> recordList = record instanceof List ? (List<Writable>) record : new ArrayList<>(record);
 
@@ -222,6 +221,9 @@ public class SVMLightRecordWriter extends FileRecordWriter {
             String line = result.substring(1).toString();
             out.write(line.getBytes());
             out.write(NEW_LINE.getBytes());
+
         }
+
+        return PartitionMetaData.builder().numRecordsUpdated(1).build();
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
@@ -19,10 +19,7 @@ package org.datavec.api.split;
 import org.datavec.api.io.filters.PathFilter;
 import org.datavec.api.util.files.ShuffledListIterator;
 import org.datavec.api.util.files.UriFromPathIterator;
-import org.datavec.api.writable.WritableType;
 
-import java.io.DataOutput;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -40,6 +37,16 @@ public abstract class BaseInputSplit implements InputSplit {
     protected List<String> uriStrings; //URIs, as a String, via toString() method (which includes file:/ etc)
     protected int[] iterationOrder;
     protected long length = 0;
+
+    @Override
+    public String addNewLocation() {
+        throw new UnsupportedOperationException("Unable to add new location.");
+    }
+
+    @Override
+    public String addNewLocation(String location) {
+        throw new UnsupportedOperationException("Unable to add new location.");
+    }
 
     @Override
     public URI[] locations() {

--- a/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
@@ -73,30 +73,7 @@ public abstract class BaseInputSplit implements InputSplit {
         return 0;
     }
 
-    @Override
-    public double toDouble() {
-        throw new UnsupportedOperationException();
-    }
 
-    @Override
-    public float toFloat() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int toInt() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long toLong() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void writeType(DataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
-    }
 
     /**
      * Samples the locations based on the PathFilter and splits the result into
@@ -138,8 +115,4 @@ public abstract class BaseInputSplit implements InputSplit {
         }
     }
 
-    @Override
-    public WritableType getType() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/BaseInputSplit.java
@@ -50,6 +50,10 @@ public abstract class BaseInputSplit implements InputSplit {
 
     @Override
     public URI[] locations() {
+        if(uriStrings == null) {
+            uriStrings = new ArrayList<>();
+        }
+
         URI[] uris = new URI[uriStrings.size()];
         int i = 0;
         for (String s : uriStrings) {

--- a/datavec-api/src/main/java/org/datavec/api/split/CollectionInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/CollectionInputSplit.java
@@ -16,10 +16,7 @@
 
 package org.datavec.api.split;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,6 +41,21 @@ public class CollectionInputSplit extends BaseInputSplit {
     }
 
     @Override
+    public boolean needsBootStrapForWrite() {
+        return false;
+    }
+
+    @Override
+    public void bootStrapForWrite() {
+
+    }
+
+    @Override
+    public OutputStream openOutputStreamFor(String location) throws Exception {
+        return null;
+    }
+
+    @Override
     public InputStream openInputStreamFor(String location) throws Exception {
         return null;
     }
@@ -63,33 +75,4 @@ public class CollectionInputSplit extends BaseInputSplit {
         return true;
     }
 
-    @Override
-    public void write(DataOutput out) throws IOException {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public void readFields(DataInput in) throws IOException {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public double toDouble() {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public float toFloat() {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public int toInt() {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public long toLong() {
-        throw new UnsupportedOperationException("Not supported");
-    }
-}
+ }

--- a/datavec-api/src/main/java/org/datavec/api/split/CollectionInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/CollectionInputSplit.java
@@ -41,7 +41,12 @@ public class CollectionInputSplit extends BaseInputSplit {
     }
 
     @Override
-    public boolean needsBootStrapForWrite() {
+    public void updateSplitLocations(boolean reset) {
+
+    }
+
+    @Override
+    public boolean needsBootstrapForWrite() {
         return false;
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
@@ -20,7 +20,6 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.datavec.api.util.files.URIUtil;
-import org.datavec.api.writable.WritableType;
 import org.nd4j.linalg.collection.CompactHeapStringList;
 import org.nd4j.linalg.util.MathUtils;
 
@@ -29,10 +28,7 @@ import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.Random;
+import java.util.*;
 
 /**
  * File input split. Splits up a root directory in to files.
@@ -103,6 +99,7 @@ public class FileSplit extends BaseInputSplit {
                 for (int i = 0; i < iterationOrder.length; i++) {
                     iterationOrder[i] = i;
                 }
+
                 MathUtils.shuffleArray(iterationOrder, random);
             }
             for (File f : subFiles) {
@@ -118,7 +115,33 @@ public class FileSplit extends BaseInputSplit {
     }
 
     @Override
-    public boolean needsBootStrapForWrite() {
+    public String addNewLocation() {
+        return addNewLocation(new File(rootDir, UUID.randomUUID().toString()).toURI().toString());
+    }
+
+    @Override
+    public String addNewLocation(String location) {
+        File f = new File(URI.create(location));
+        try {
+            f.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        uriStrings.add(location);
+        ++length;
+        return location;
+    }
+
+    @Override
+    public void updateSplitLocations(boolean reset) {
+        if (reset) {
+            initialize();
+        }
+    }
+
+    @Override
+    public boolean needsBootstrapForWrite() {
         return locations() == null ||
                 locations().length < 1
                 || locations().length == 1 && !locations()[0].isAbsolute();

--- a/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
@@ -83,6 +83,20 @@ public class FileSplit extends BaseInputSplit {
 
         if (rootDir == null)
             throw new IllegalArgumentException("File path must not be null");
+        else if(rootDir.isAbsolute() && !rootDir.exists()) {
+            try {
+                if(!rootDir.createNewFile()) {
+                    throw new IllegalArgumentException("Unable to create file " + rootDir.getAbsolutePath());
+                }
+                //ensure uri strings has the root file if it's not a directory
+                else {
+                    uriStrings = new ArrayList<>();
+                    uriStrings.add(rootDir.toURI().toString());
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
         else if (!rootDir.getAbsoluteFile().exists())
             // When implementing wild card characters in the rootDir, remove this if exists,
             // verify expanded paths exist and check for the edge case when expansion cannot be

--- a/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
@@ -125,7 +125,7 @@ public class FileSplit extends BaseInputSplit {
         try {
             f.createNewFile();
         } catch (IOException e) {
-            e.printStackTrace();
+           throw new IllegalStateException(e);
         }
 
         uriStrings.add(location);
@@ -157,7 +157,7 @@ public class FileSplit extends BaseInputSplit {
                 //since locations are dynamically generated, allow
                 uriStrings.add(writeFile.toURI().toString());
             } catch (IOException e) {
-                e.printStackTrace();
+               throw new IllegalStateException(e);
             }
 
 
@@ -167,14 +167,14 @@ public class FileSplit extends BaseInputSplit {
     @Override
     public OutputStream openOutputStreamFor(String location) throws Exception {
         FileOutputStream ret = location.startsWith("file://") ? new FileOutputStream(new File(URI.create(location))):
-                new FileOutputStream(new File(location));
+                new FileOutputStream(new File(URI.create(location)));
         return ret;
     }
 
     @Override
     public InputStream openInputStreamFor(String location) throws Exception {
         FileInputStream ret = location.startsWith("file://") ? new FileInputStream(new File(URI.create(location))):
-                new FileInputStream(new File(location));
+                new FileInputStream(new File(URI.create(location)));
         return ret;
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/FileSplit.java
@@ -16,6 +16,7 @@
 
 package org.datavec.api.split;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
@@ -123,14 +124,21 @@ public class FileSplit extends BaseInputSplit {
         } else {
             // Lists one file
             String toString = URIUtil.fileToURI(rootDir).toString(); //URI.getPath(), getRawPath() etc don't have file:/ prefix necessary for conversion back to URI
-            uriStrings = Collections.singletonList(toString);
+            uriStrings = new ArrayList<>(1);
+            uriStrings.add(toString);
             length += rootDir.length();
         }
     }
 
     @Override
     public String addNewLocation() {
-        return addNewLocation(new File(rootDir, UUID.randomUUID().toString()).toURI().toString());
+        if(rootDir.isDirectory())
+            return addNewLocation(new File(rootDir, UUID.randomUUID().toString()).toURI().toString());
+        else {
+            //add a file in the same directory as the file with the same extension as the original file
+            return addNewLocation(new File(rootDir.getParent(), UUID.randomUUID().toString() + "." + FilenameUtils.getExtension(rootDir.getAbsolutePath())).toURI().toString());
+
+        }
     }
 
     @Override
@@ -139,7 +147,7 @@ public class FileSplit extends BaseInputSplit {
         try {
             f.createNewFile();
         } catch (IOException e) {
-           throw new IllegalStateException(e);
+            throw new IllegalStateException(e);
         }
 
         uriStrings.add(location);
@@ -171,7 +179,7 @@ public class FileSplit extends BaseInputSplit {
                 //since locations are dynamically generated, allow
                 uriStrings.add(writeFile.toURI().toString());
             } catch (IOException e) {
-               throw new IllegalStateException(e);
+                throw new IllegalStateException(e);
             }
 
 

--- a/datavec-api/src/main/java/org/datavec/api/split/InputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/InputSplit.java
@@ -17,9 +17,8 @@
 package org.datavec.api.split;
 
 
-import org.datavec.api.writable.Writable;
-
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Iterator;
 
@@ -31,8 +30,35 @@ import java.util.Iterator;
  *
  * @author Adam Gibson
  */
-public interface InputSplit extends Writable {
+public interface InputSplit  {
 
+
+    /**
+     * Returns true if this {@link InputSplit}
+     * needs bootstrapping for writing.
+     * A simple example of needing bootstrapping is for
+     * {@link FileSplit} where there is only a directory
+     * existing, but no file to write to
+     * @return true if this input split needs bootstrapping for
+     * writing to or not
+     */
+    boolean needsBootStrapForWrite();
+
+    /**
+     * Bootstrap this input split for writing.
+     * This is for use with {@link org.datavec.api.records.writer.RecordWriter}
+     */
+    void bootStrapForWrite();
+
+    /**
+     * Open an {@link OutputStream}
+     * for the given location.
+     * Note that the user is responsible for closing
+     * the associated output stream.
+     * @param location the location to open the output stream for
+     * @return the output input stream
+     */
+    OutputStream openOutputStreamFor(String location) throws Exception;
 
     /**
      * Open an {@link InputStream}

--- a/datavec-api/src/main/java/org/datavec/api/split/InputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/InputSplit.java
@@ -34,6 +34,29 @@ public interface InputSplit  {
 
 
     /**
+     * Add a new location with the name generated
+     *  by this input split/
+     */
+    String addNewLocation();
+
+    /**
+     * Add a new location to this input split
+     * (this  may do anything from updating an in memory location
+     * to creating a new file)
+     * @param location the location to add
+     */
+    String addNewLocation(String location);
+
+    /**
+     * Refreshes the split locations
+     * if needed in memory.
+     * (Think a few file gets added)
+     * @param reset
+     */
+    void updateSplitLocations(boolean reset);
+
+
+    /**
      * Returns true if this {@link InputSplit}
      * needs bootstrapping for writing.
      * A simple example of needing bootstrapping is for
@@ -42,7 +65,7 @@ public interface InputSplit  {
      * @return true if this input split needs bootstrapping for
      * writing to or not
      */
-    boolean needsBootStrapForWrite();
+    boolean needsBootstrapForWrite();
 
     /**
      * Bootstrap this input split for writing.

--- a/datavec-api/src/main/java/org/datavec/api/split/InputStreamInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/InputStreamInputSplit.java
@@ -16,9 +16,9 @@
 
 package org.datavec.api.split;
 
-import org.datavec.api.writable.WritableType;
-
-import java.io.*;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
@@ -73,7 +73,22 @@ public class InputStreamInputSplit implements InputSplit {
     }
 
     @Override
-    public boolean needsBootStrapForWrite() {
+    public String addNewLocation() {
+        return null;
+    }
+
+    @Override
+    public String addNewLocation(String location) {
+        return null;
+    }
+
+    @Override
+    public void updateSplitLocations(boolean reset) {
+
+    }
+
+    @Override
+    public boolean needsBootstrapForWrite() {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/split/InputStreamInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/InputStreamInputSplit.java
@@ -73,6 +73,22 @@ public class InputStreamInputSplit implements InputSplit {
     }
 
     @Override
+    public boolean needsBootStrapForWrite() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void bootStrapForWrite() {
+        throw new UnsupportedOperationException();
+
+    }
+
+    @Override
+    public OutputStream openOutputStreamFor(String location) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public InputStream openInputStreamFor(String location) throws Exception {
         return is;
     }
@@ -110,15 +126,6 @@ public class InputStreamInputSplit implements InputSplit {
         return location != null;
     }
 
-    @Override
-    public void write(DataOutput out) throws IOException {
-
-    }
-
-    @Override
-    public void readFields(DataInput in) throws IOException {
-
-    }
 
     public InputStream getIs() {
         return is;
@@ -128,33 +135,4 @@ public class InputStreamInputSplit implements InputSplit {
         this.is = is;
     }
 
-    @Override
-    public double toDouble() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public float toFloat() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int toInt() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long toLong() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public WritableType getType() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void writeType(DataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/ListStringSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/ListStringSplit.java
@@ -16,9 +16,8 @@
 
 package org.datavec.api.split;
 
-import org.datavec.api.writable.WritableType;
-
-import java.io.*;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
@@ -37,7 +36,22 @@ public class ListStringSplit implements InputSplit {
     }
 
     @Override
-    public boolean needsBootStrapForWrite() {
+    public String addNewLocation() {
+        return null;
+    }
+
+    @Override
+    public String addNewLocation(String location) {
+        return null;
+    }
+
+    @Override
+    public void updateSplitLocations(boolean reset) {
+
+    }
+
+    @Override
+    public boolean needsBootstrapForWrite() {
         return false;
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/split/ListStringSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/ListStringSplit.java
@@ -18,10 +18,7 @@ package org.datavec.api.split;
 
 import org.datavec.api.writable.WritableType;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
@@ -37,6 +34,21 @@ public class ListStringSplit implements InputSplit {
 
     public ListStringSplit(List<List<String>> data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean needsBootStrapForWrite() {
+        return false;
+    }
+
+    @Override
+    public void bootStrapForWrite() {
+
+    }
+
+    @Override
+    public OutputStream openOutputStreamFor(String location) throws Exception {
+        return null;
     }
 
     @Override
@@ -84,72 +96,7 @@ public class ListStringSplit implements InputSplit {
         return true;
     }
 
-    /**
-     * Serialize the fields of this object to <code>out</code>.
-     *
-     * @param out <code>DataOuput</code> to serialize this object into.
-     * @throws IOException
-     */
-    @Override
-    public void write(DataOutput out) throws IOException {
 
-    }
-
-    /**
-     * Deserialize the fields of this object from <code>in</code>.
-     * <p>
-     * <p>For efficiency, implementations should attempt to re-use storage in the
-     * existing object where possible.</p>
-     *
-     * @param in <code>DataInput</code> to deseriablize this object from.
-     * @throws IOException
-     */
-    @Override
-    public void readFields(DataInput in) throws IOException {
-
-    }
-
-    /**
-     * Convert Writable to double. Whether this is supported depends on the specific writable.
-     */
-    @Override
-    public double toDouble() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Convert Writable to float. Whether this is supported depends on the specific writable.
-     */
-    @Override
-    public float toFloat() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Convert Writable to int. Whether this is supported depends on the specific writable.
-     */
-    @Override
-    public int toInt() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Convert Writable to long. Whether this is supported depends on the specific writable.
-     */
-    @Override
-    public long toLong() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public WritableType getType() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void writeType(DataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
-    }
 
     public List<List<String>> getData() {
         return data;

--- a/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
@@ -60,6 +60,35 @@ public class NumberedFileInputSplit implements InputSplit {
     }
 
     @Override
+    public boolean needsBootStrapForWrite() {
+        return locations() == null ||
+                locations().length < 1
+                || locations().length == 1 && !locations()[0].isAbsolute();
+    }
+
+    @Override
+    public void bootStrapForWrite() {
+        if(locations().length == 1 && !locations()[0].isAbsolute()) {
+            File parentDir = new File(locations()[0]);
+            File writeFile = new File(parentDir,"write-file");
+            try {
+                writeFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+
+        }
+    }
+
+    @Override
+    public OutputStream openOutputStreamFor(String location) throws Exception {
+        FileOutputStream ret = location.startsWith("file://") ? new FileOutputStream(new File(URI.create(location))):
+                new FileOutputStream(new File(location));
+        return ret;
+    }
+
+    @Override
     public InputStream openInputStreamFor(String location) throws Exception {
         FileInputStream fileInputStream = new FileInputStream(location);
         return fileInputStream;
@@ -100,45 +129,6 @@ public class NumberedFileInputSplit implements InputSplit {
         return true;
     }
 
-    @Override
-    public void write(DataOutput out) throws IOException {
-
-    }
-
-    @Override
-    public void readFields(DataInput in) throws IOException {
-
-    }
-
-    @Override
-    public double toDouble() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public float toFloat() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int toInt() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long toLong() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public WritableType getType() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void writeType(DataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
-    }
 
     private class NumberedFileIterator implements Iterator<String> {
 

--- a/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
@@ -60,7 +60,22 @@ public class NumberedFileInputSplit implements InputSplit {
     }
 
     @Override
-    public boolean needsBootStrapForWrite() {
+    public String addNewLocation() {
+        return null;
+    }
+
+    @Override
+    public String addNewLocation(String location) {
+        return null;
+    }
+
+    @Override
+    public void updateSplitLocations(boolean reset) {
+        //no-op (locations() is dynamic)
+    }
+
+    @Override
+    public boolean needsBootstrapForWrite() {
         return locations() == null ||
                 locations().length < 1
                 || locations().length == 1 && !locations()[0].isAbsolute();

--- a/datavec-api/src/main/java/org/datavec/api/split/StringSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/StringSplit.java
@@ -16,12 +16,8 @@
 
 package org.datavec.api.split;
 
-import org.datavec.api.writable.WritableType;
-
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
@@ -35,6 +31,21 @@ public class StringSplit implements InputSplit {
 
     public StringSplit(String data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean needsBootStrapForWrite() {
+        return false;
+    }
+
+    @Override
+    public void bootStrapForWrite() {
+
+    }
+
+    @Override
+    public OutputStream openOutputStreamFor(String location) throws Exception {
+        return null;
     }
 
     @Override
@@ -72,47 +83,10 @@ public class StringSplit implements InputSplit {
         return true;
     }
 
-    @Override
-    public void write(DataOutput out) throws IOException {
-        out.write(data.getBytes());
-    }
 
-    @Override
-    public void readFields(DataInput in) throws IOException {
-
-    }
 
     public String getData() {
         return data;
     }
 
-    @Override
-    public double toDouble() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public float toFloat() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int toInt() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long toLong() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public WritableType getType() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void writeType(DataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/StringSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/StringSplit.java
@@ -34,7 +34,22 @@ public class StringSplit implements InputSplit {
     }
 
     @Override
-    public boolean needsBootStrapForWrite() {
+    public String addNewLocation() {
+        return null;
+    }
+
+    @Override
+    public String addNewLocation(String location) {
+        return null;
+    }
+
+    @Override
+    public void updateSplitLocations(boolean reset) {
+
+    }
+
+    @Override
+    public boolean needsBootstrapForWrite() {
         return false;
     }
 

--- a/datavec-api/src/main/java/org/datavec/api/split/TransformSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/TransformSplit.java
@@ -3,10 +3,7 @@ package org.datavec.api.split;
 import lombok.NonNull;
 import org.nd4j.linalg.collection.CompactHeapStringList;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Iterator;
@@ -65,14 +62,21 @@ public class TransformSplit extends BaseInputSplit {
         }
     }
 
+
+
     @Override
-    public void write(DataOutput out) throws IOException {
+    public boolean needsBootStrapForWrite() {
+        return false;
+    }
+
+    @Override
+    public void bootStrapForWrite() {
 
     }
 
     @Override
-    public void readFields(DataInput in) throws IOException {
-
+    public OutputStream openOutputStreamFor(String location) throws Exception {
+        return sourceSplit.openOutputStreamFor(location);
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/split/TransformSplit.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/TransformSplit.java
@@ -27,7 +27,7 @@ public class TransformSplit extends BaseInputSplit {
      * @throws URISyntaxException thrown if the transformed URI is malformed
      */
     public TransformSplit(@NonNull BaseInputSplit sourceSplit, @NonNull URITransform transform)
-                    throws URISyntaxException {
+            throws URISyntaxException {
         this.sourceSplit = sourceSplit;
         this.transform = transform;
         initialize();
@@ -42,7 +42,7 @@ public class TransformSplit extends BaseInputSplit {
      * @throws URISyntaxException thrown if the transformed URI is malformed
      */
     public static TransformSplit ofSearchReplace(@NonNull BaseInputSplit sourceSplit, @NonNull final String search,
-                    @NonNull final String replace) throws URISyntaxException {
+                                                 @NonNull final String replace) throws URISyntaxException {
         return new TransformSplit(sourceSplit, new URITransform() {
             @Override
             public URI apply(URI uri) throws URISyntaxException {
@@ -63,15 +63,19 @@ public class TransformSplit extends BaseInputSplit {
     }
 
 
+    @Override
+    public void updateSplitLocations(boolean reset) {
+        sourceSplit.updateSplitLocations(reset);
+    }
 
     @Override
-    public boolean needsBootStrapForWrite() {
-        return false;
+    public boolean needsBootstrapForWrite() {
+        return sourceSplit.needsBootstrapForWrite();
     }
 
     @Override
     public void bootStrapForWrite() {
-
+        sourceSplit.bootStrapForWrite();
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
@@ -72,12 +72,27 @@ public class NumberOfRecordsPartitioner implements Partitioner {
 
     @Override
     public OutputStream openNewStream() {
-        String newInput = inputSplit.addNewLocation();
-        try {
-            return inputSplit.openOutputStreamFor(newInput);
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
+        if(currLocation >= locations.length - 1) {
+            String newInput = inputSplit.addNewLocation();
+            try {
+                OutputStream ret =  inputSplit.openOutputStreamFor(newInput);
+                this.current = ret;
+                return ret;
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
         }
+        else {
+            try {
+                OutputStream ret=  inputSplit.openOutputStreamFor(locations[currLocation].toString());
+                currLocation++;
+                this.current = ret;
+                return ret;
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
@@ -72,7 +72,8 @@ public class NumberOfRecordsPartitioner implements Partitioner {
 
     @Override
     public OutputStream openNewStream() {
-        if(currLocation >= locations.length - 1) {
+        //only append when directory
+        if(currLocation >= locations.length - 1 && locations.length >= 1 && !locations[0].isAbsolute()) {
             String newInput = inputSplit.addNewLocation();
             try {
                 OutputStream ret =  inputSplit.openOutputStreamFor(newInput);
@@ -97,6 +98,9 @@ public class NumberOfRecordsPartitioner implements Partitioner {
 
     @Override
     public OutputStream currentOutputStream() {
+        if(current == null) {
+            current = openNewStream();
+        }
         return current;
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
@@ -3,8 +3,18 @@ package org.datavec.api.split.partition;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.split.InputSplit;
 
+import java.io.OutputStream;
 import java.net.URI;
 
+/**
+ * Partition relative to number of records written per file.
+ * This partitioner will ensure that no more than
+ * {@link #recordsPerFile} number of records is written per
+ * file when outputting to the various locations of the
+ * {@link InputSplit} locations.
+ *
+ * @author Adam Gibson
+ */
 public class NumberOfRecordsPartitioner implements Partitioner {
 
     private URI[] locations;
@@ -13,6 +23,10 @@ public class NumberOfRecordsPartitioner implements Partitioner {
     public final static int DEFAULT_RECORDS_PER_FILE = -1;
 
     public final static String RECORDS_PER_FILE_CONFIG = "org.datavec.api.split.partition.numrecordsperfile";
+    private int numRecordsSoFar = 0;
+    private int currLocation;
+    private InputSplit inputSplit;
+    private OutputStream current;
 
     @Override
     public int numPartitions() {
@@ -35,11 +49,39 @@ public class NumberOfRecordsPartitioner implements Partitioner {
     @Override
     public void init(InputSplit inputSplit) {
         this.locations = inputSplit.locations();
+        this.inputSplit = inputSplit;
+
     }
 
     @Override
     public void init(Configuration configuration, InputSplit split) {
         init(split);
         this.recordsPerFile = configuration.getInt(RECORDS_PER_FILE_CONFIG,DEFAULT_RECORDS_PER_FILE);
+    }
+
+    @Override
+    public void updatePartitionInfo(Object... metadata) {
+        Integer numRecords = (Integer) metadata[0];
+        this.numRecordsSoFar += numRecords;
+    }
+
+    @Override
+    public boolean needsNewPartition() {
+        return numRecordsSoFar >= recordsPerFile;
+    }
+
+    @Override
+    public OutputStream openNewStream() {
+        String newInput = inputSplit.addNewLocation();
+        try {
+            return inputSplit.openOutputStreamFor(newInput);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public OutputStream currentOutputStream() {
+        return current;
     }
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
@@ -29,6 +29,11 @@ public class NumberOfRecordsPartitioner implements Partitioner {
     private OutputStream current;
 
     @Override
+    public int numRecordsWritten() {
+        return numRecordsSoFar;
+    }
+
+    @Override
     public int numPartitions() {
         //possible it's a directory
         if(locations.length < 2) {
@@ -66,13 +71,13 @@ public class NumberOfRecordsPartitioner implements Partitioner {
 
     @Override
     public boolean needsNewPartition() {
-        return numRecordsSoFar >= recordsPerFile;
+        return recordsPerFile > 0 && numRecordsSoFar >= recordsPerFile;
     }
 
     @Override
     public OutputStream openNewStream() {
         //only append when directory
-        if(currLocation >= locations.length - 1 && locations.length >= 1 && !locations[0].isAbsolute()) {
+        if(currLocation >= locations.length - 1 && locations.length >= 1 && needsNewPartition()) {
             String newInput = inputSplit.addNewLocation();
             try {
                 OutputStream ret =  inputSplit.openOutputStreamFor(newInput);

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
@@ -1,0 +1,45 @@
+package org.datavec.api.split.partition;
+
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.split.InputSplit;
+
+import java.net.URI;
+
+public class NumberOfRecordsPartitioner implements Partitioner {
+
+    private URI[] locations;
+    private int recordsPerFile = DEFAULT_RECORDS_PER_FILE;
+    //all records in to 1 file
+    public final static int DEFAULT_RECORDS_PER_FILE = -1;
+
+    public final static String RECORDS_PER_FILE_CONFIG = "org.datavec.api.split.partition.numrecordsperfile";
+
+    @Override
+    public int numPartitions() {
+        //possible it's a directory
+        if(locations.length < 2) {
+
+            if(locations.length > 0 && locations[0].isAbsolute()) {
+                return recordsPerFile;
+            }
+            //append all results to 1 file when -1
+            else {
+                return 1;
+            }
+        }
+
+        //otherwise it's a series of specified files.
+        return locations.length / recordsPerFile;
+    }
+
+    @Override
+    public void init(InputSplit inputSplit) {
+        this.locations = inputSplit.locations();
+    }
+
+    @Override
+    public void init(Configuration configuration, InputSplit split) {
+        init(split);
+        this.recordsPerFile = configuration.getInt(RECORDS_PER_FILE_CONFIG,DEFAULT_RECORDS_PER_FILE);
+    }
+}

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/NumberOfRecordsPartitioner.java
@@ -60,9 +60,8 @@ public class NumberOfRecordsPartitioner implements Partitioner {
     }
 
     @Override
-    public void updatePartitionInfo(Object... metadata) {
-        Integer numRecords = (Integer) metadata[0];
-        this.numRecordsSoFar += numRecords;
+    public void updatePartitionInfo(PartitionMetaData metadata) {
+        this.numRecordsSoFar += metadata.getNumRecordsUpdated();
     }
 
     @Override

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/PartitionMetaData.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/PartitionMetaData.java
@@ -1,0 +1,19 @@
+package org.datavec.api.split.partition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@Getter
+public class PartitionMetaData implements Serializable {
+    private int numRecordsUpdated;
+    private long sizeUpdated;
+
+
+}

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
@@ -39,11 +39,11 @@ public interface Partitioner {
      * (to indicate whether the next partition is needed or not)
      * @param metadata
      */
-    void updatePartitionInfo(Object...metadata);
+    void updatePartitionInfo(PartitionMetaData metadata);
 
     /**
      * Returns true if the partition needs to be moved to the next.
-     * This is controlled with {@link #updatePartitionInfo(Object...)}
+     * This is controlled with {@link #updatePartitionInfo(PartitionMetaData)}
      * which handles incrementing counters and the like
      * to determine whether the current partition has been exhausted.
      * @return

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
@@ -13,6 +13,13 @@ import java.io.OutputStream;
 public interface Partitioner {
 
     /**
+     * Number of records written so far
+     *
+     * @return
+     */
+    int numRecordsWritten();
+
+    /**
      * Returns the number of partitions
      * @return
      */

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
@@ -3,13 +3,59 @@ package org.datavec.api.split.partition;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.split.InputSplit;
 
+import java.io.OutputStream;
+
 public interface Partitioner {
 
+    /**
+     * Returns the number of partitions
+     * @return
+     */
     int numPartitions();
 
+    /**
+     * Initializes this partitioner with the given configuration
+     * and input split
+     * @param inputSplit the input split to use with this partitioner
+     */
     void init(InputSplit inputSplit);
 
+    /**
+     * Initializes this partitioner with the given configuration
+     * and input split
+     * @param configuration the configuration to configure
+     *                      this partitioner with
+     * @param split the input split to use with this partitioner
+     */
     void init(Configuration configuration,InputSplit split);
 
+    /**
+     * Updates the metadata for this partitioner
+     * (to indicate whether the next partition is needed or not)
+     * @param metadata
+     */
+    void updatePartitionInfo(Object...metadata);
+
+    /**
+     * Returns true if the partition needs to be moved to the next.
+     * This is controlled with {@link #updatePartitionInfo(Object...)}
+     * which handles incrementing counters and the like
+     * to determine whether the current partition has been exhausted.
+     * @return
+     */
+    boolean needsNewPartition();
+
+
+    /**
+     * "Increment" to the next stream
+     * @return the new opened output stream
+     */
+    OutputStream openNewStream();
+
+    /**
+     * Get the current output stream
+     * @return
+     */
+    OutputStream currentOutputStream();
 
 }

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
@@ -1,0 +1,15 @@
+package org.datavec.api.split.partition;
+
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.split.InputSplit;
+
+public interface Partitioner {
+
+    int numPartitions();
+
+    void init(InputSplit inputSplit);
+
+    void init(Configuration configuration,InputSplit split);
+
+
+}

--- a/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
+++ b/datavec-api/src/main/java/org/datavec/api/split/partition/Partitioner.java
@@ -5,6 +5,11 @@ import org.datavec.api.split.InputSplit;
 
 import java.io.OutputStream;
 
+/**
+ * A partitioner for iterating thorugh files for {@link org.datavec.api.records.writer.RecordWriter}.
+ * This allows for a configurable log rotation like algorithm for partitioning files by number of recodrds,
+ * sizes among other things.
+ */
 public interface Partitioner {
 
     /**
@@ -57,5 +62,7 @@ public interface Partitioner {
      * @return
      */
     OutputStream currentOutputStream();
+
+
 
 }

--- a/datavec-api/src/main/java/org/datavec/api/writable/Writable.java
+++ b/datavec-api/src/main/java/org/datavec/api/writable/Writable.java
@@ -111,6 +111,10 @@ public interface Writable extends Serializable {
     /** Convert Writable to long. Whether this is supported depends on the specific writable. */
     long toLong();
 
+    /**
+     * Get the type of the writable.
+     * @return
+     */
     WritableType getType();
 
 }

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -109,7 +109,6 @@ public class CSVRecordReaderTest {
 
     @Test
     public void testWrite() throws Exception {
-
         List<List<Writable>> list = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 10; i++) {
@@ -195,7 +194,6 @@ public class CSVRecordReaderTest {
 
     @Test
     public void testMeta() throws Exception {
-
         CSVRecordReader rr = new CSVRecordReader(0, ',');
         rr.initialize(new FileSplit(new ClassPathResource("iris.dat").getFile()));
 

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVRecordReaderTest.java
@@ -26,6 +26,7 @@ import org.datavec.api.records.writer.impl.csv.CSVRecordWriter;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputStreamInputSplit;
 import org.datavec.api.split.StringSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.util.ClassPathResource;
 import org.datavec.api.writable.IntWritable;
 import org.datavec.api.writable.Text;
@@ -130,7 +131,9 @@ public class CSVRecordReaderTest {
         Path p = Files.createTempFile("csvwritetest", "csv");
         p.toFile().deleteOnExit();
 
-        FileRecordWriter writer = new CSVRecordWriter(p.toFile());
+        FileRecordWriter writer = new CSVRecordWriter();
+        FileSplit fileSplit = new FileSplit(p.toFile());
+        writer.initialize(fileSplit,new NumberOfRecordsPartitioner());
         for (List<Writable> c : list) {
             writer.write(c);
         }

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVSequenceRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVSequenceRecordReaderTest.java
@@ -141,7 +141,22 @@ public class CSVSequenceRecordReaderTest {
     private static class TestInputSplit implements InputSplit {
 
         @Override
-        public boolean needsBootStrapForWrite() {
+        public String addNewLocation() {
+            return null;
+        }
+
+        @Override
+        public String addNewLocation(String location) {
+            return null;
+        }
+
+        @Override
+        public void updateSplitLocations(boolean reset) {
+
+        }
+
+        @Override
+        public boolean needsBootstrapForWrite() {
             return false;
         }
 

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVSequenceRecordReaderTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVSequenceRecordReaderTest.java
@@ -141,6 +141,21 @@ public class CSVSequenceRecordReaderTest {
     private static class TestInputSplit implements InputSplit {
 
         @Override
+        public boolean needsBootStrapForWrite() {
+            return false;
+        }
+
+        @Override
+        public void bootStrapForWrite() {
+
+        }
+
+        @Override
+        public OutputStream openOutputStreamFor(String location) throws Exception {
+            return null;
+        }
+
+        @Override
         public InputStream openInputStreamFor(String location) throws Exception {
             return null;
         }
@@ -188,45 +203,9 @@ public class CSVSequenceRecordReaderTest {
             return true;
         }
 
-        @Override
-        public void write(DataOutput out) throws IOException {
-            throw new UnsupportedOperationException();
-        }
 
-        @Override
-        public void readFields(DataInput in) throws IOException {
-            throw new UnsupportedOperationException();
-        }
 
-        @Override
-        public void writeType(DataOutput out) throws IOException {
-            throw new UnsupportedOperationException();
-        }
 
-        @Override
-        public double toDouble() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public float toFloat() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int toInt() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long toLong() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public WritableType getType() {
-            throw new UnsupportedOperationException();
-        }
     }
 
 

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/LibSvmTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/LibSvmTest.java
@@ -23,6 +23,7 @@ import org.datavec.api.records.writer.RecordWriter;
 import org.datavec.api.records.writer.impl.FileRecordWriter;
 import org.datavec.api.records.writer.impl.misc.LibSvmRecordWriter;
 import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.util.ClassPathResource;
 import org.datavec.api.writable.Writable;
 import org.junit.Test;
@@ -62,8 +63,9 @@ public class LibSvmTest {
         RecordReader libSvmRecordReader = new LibSvmRecordReader();
         libSvmRecordReader.initialize(conf, new FileSplit(new ClassPathResource("iris.libsvm").getFile()));
 
-        RecordWriter writer = new LibSvmRecordWriter(out, true);
-        writer.setConf(conf);
+        RecordWriter writer = new LibSvmRecordWriter();
+        FileSplit fileSplit = new FileSplit(out);
+        writer.initialize(conf,fileSplit,new NumberOfRecordsPartitioner());
         List<List<Writable>> data = new ArrayList<>();
         while (libSvmRecordReader.hasNext()) {
             List<Writable> record = libSvmRecordReader.next();

--- a/datavec-api/src/test/java/org/datavec/api/records/reader/impl/SVMRecordWriterTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/reader/impl/SVMRecordWriterTest.java
@@ -25,6 +25,7 @@ import org.datavec.api.records.writer.RecordWriter;
 import org.datavec.api.records.writer.impl.misc.SVMLightRecordWriter;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.util.ClassPathResource;
 import org.datavec.api.writable.Writable;
 import org.junit.Test;
@@ -82,7 +83,9 @@ public class SVMRecordWriterTest {
         if (out.exists())
             out.delete();
         out.deleteOnExit();
-        RecordWriter writer = new SVMLightRecordWriter(out, true);
+        FileSplit fileSplit = new FileSplit(out);
+        RecordWriter writer = new SVMLightRecordWriter();
+        writer.initialize(fileSplit,new NumberOfRecordsPartitioner());
         for (List<Writable> record : records)
             writer.write(record);
 

--- a/datavec-api/src/test/java/org/datavec/api/records/writer/impl/CSVRecordWriterTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/writer/impl/CSVRecordWriterTest.java
@@ -19,6 +19,7 @@ package org.datavec.api.records.writer.impl;
 import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
 import org.datavec.api.records.writer.impl.csv.CSVRecordWriter;
 import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
 import org.junit.Before;
@@ -44,9 +45,9 @@ public class CSVRecordWriterTest {
     public void testWrite() throws Exception {
         File tempFile = File.createTempFile("datavec", "writer");
         tempFile.deleteOnExit();
-
-        CSVRecordWriter writer = new CSVRecordWriter(tempFile);
-
+        FileSplit fileSplit = new FileSplit(tempFile);
+        CSVRecordWriter writer = new CSVRecordWriter();
+        writer.initialize(fileSplit,new NumberOfRecordsPartitioner());
         List<Writable> collection = new ArrayList<>();
         collection.add(new Text("12"));
         collection.add(new Text("13"));

--- a/datavec-api/src/test/java/org/datavec/api/records/writer/impl/LibSvmRecordWriterTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/writer/impl/LibSvmRecordWriterTest.java
@@ -21,6 +21,7 @@ import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.reader.impl.misc.LibSvmRecordReader;
 import org.datavec.api.records.writer.impl.misc.LibSvmRecordWriter;
 import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.util.ClassPathResource;
 import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.IntWritable;
@@ -131,9 +132,9 @@ public class LibSvmRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
-            writer.setConf(configWriter);
-
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
+           FileSplit outputSplit = new FileSplit(tempFile);
+           writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             LibSvmRecordReader rr = new LibSvmRecordReader();
             rr.initialize(configReader, new FileSplit(inputFile));
             while (rr.hasNext()) {
@@ -184,11 +185,12 @@ public class LibSvmRecordWriterTest {
 
         String lineOriginal = "13.0,14.0,15.0,4 1:1.0 2:11.0 3:12.0 4:2.0 5:3.0";
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(LibSvmRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_LAST_COLUMN, 3);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
 
@@ -219,12 +221,13 @@ public class LibSvmRecordWriterTest {
 
         String lineOriginal = "2,4 1:1.0 2:11.0 3:12.0 4:2.0 5:3.0";
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setBoolean(LibSvmRecordWriter.MULTILABEL, true);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_LAST_COLUMN, 3);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
 
@@ -255,14 +258,15 @@ public class LibSvmRecordWriterTest {
 
         String lineOriginal = "1,3 0:1.0 1:11.0 2:12.0 3:2.0 4:3.0";
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setBoolean(LibSvmRecordWriter.ZERO_BASED_INDEXING, true); // NOT STANDARD!
             configWriter.setBoolean(LibSvmRecordWriter.ZERO_BASED_LABEL_INDEXING, true); // NOT STANDARD!
             configWriter.setBoolean(LibSvmRecordWriter.MULTILABEL, true);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_LAST_COLUMN, 3);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
 
@@ -281,12 +285,13 @@ public class LibSvmRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(LibSvmRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_LAST_COLUMN, 1);
             configWriter.setBoolean(LibSvmRecordWriter.MULTILABEL, true);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
     }
@@ -302,12 +307,13 @@ public class LibSvmRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(LibSvmRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_LAST_COLUMN, 1);
             configWriter.setBoolean(LibSvmRecordWriter.MULTILABEL, true);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
     }
@@ -323,12 +329,13 @@ public class LibSvmRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (LibSvmRecordWriter writer = new LibSvmRecordWriter(tempFile, true)) {
+        try (LibSvmRecordWriter writer = new LibSvmRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(LibSvmRecordWriter.FEATURE_FIRST_COLUMN,0);
             configWriter.setInt(LibSvmRecordWriter.FEATURE_LAST_COLUMN,1);
             configWriter.setBoolean(LibSvmRecordWriter.MULTILABEL,true);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
     }

--- a/datavec-api/src/test/java/org/datavec/api/records/writer/impl/SVMLightRecordWriterTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/records/writer/impl/SVMLightRecordWriterTest.java
@@ -21,6 +21,7 @@ import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.reader.impl.misc.SVMLightRecordReader;
 import org.datavec.api.records.writer.impl.misc.SVMLightRecordWriter;
 import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.util.ClassPathResource;
 import org.datavec.api.writable.*;
 import org.datavec.api.writable.NDArrayWritable;
@@ -129,9 +130,9 @@ public class SVMLightRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
-            writer.setConf(configWriter);
-
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             SVMLightRecordReader rr = new SVMLightRecordReader();
             rr.initialize(configReader, new FileSplit(inputFile));
             while (rr.hasNext()) {
@@ -182,11 +183,12 @@ public class SVMLightRecordWriterTest {
 
         String lineOriginal = "13.0,14.0,15.0,4 1:1.0 2:11.0 3:12.0 4:2.0 5:3.0";
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(SVMLightRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_LAST_COLUMN, 3);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
 
@@ -217,12 +219,13 @@ public class SVMLightRecordWriterTest {
 
         String lineOriginal = "2,4 1:1.0 2:11.0 3:12.0 4:2.0 5:3.0";
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setBoolean(SVMLightRecordWriter.MULTILABEL, true);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_LAST_COLUMN, 3);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
 
@@ -253,14 +256,15 @@ public class SVMLightRecordWriterTest {
 
         String lineOriginal = "1,3 0:1.0 1:11.0 2:12.0 3:2.0 4:3.0";
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setBoolean(SVMLightRecordWriter.ZERO_BASED_INDEXING, true); // NOT STANDARD!
             configWriter.setBoolean(SVMLightRecordWriter.ZERO_BASED_LABEL_INDEXING, true); // NOT STANDARD!
             configWriter.setBoolean(SVMLightRecordWriter.MULTILABEL, true);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_LAST_COLUMN, 3);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
 
@@ -279,12 +283,13 @@ public class SVMLightRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(SVMLightRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_LAST_COLUMN, 1);
             configWriter.setBoolean(SVMLightRecordWriter.MULTILABEL, true);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
     }
@@ -300,12 +305,13 @@ public class SVMLightRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(SVMLightRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_LAST_COLUMN, 1);
             configWriter.setBoolean(SVMLightRecordWriter.MULTILABEL, true);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
     }
@@ -321,12 +327,13 @@ public class SVMLightRecordWriterTest {
         if (tempFile.exists())
             tempFile.delete();
 
-        try (SVMLightRecordWriter writer = new SVMLightRecordWriter(tempFile, true)) {
+        try (SVMLightRecordWriter writer = new SVMLightRecordWriter()) {
             Configuration configWriter = new Configuration();
             configWriter.setInt(SVMLightRecordWriter.FEATURE_FIRST_COLUMN, 0);
             configWriter.setInt(SVMLightRecordWriter.FEATURE_LAST_COLUMN, 1);
             configWriter.setBoolean(SVMLightRecordWriter.MULTILABEL, true);
-            writer.setConf(configWriter);
+            FileSplit outputSplit = new FileSplit(tempFile);
+            writer.initialize(configWriter,outputSplit,new NumberOfRecordsPartitioner());
             writer.write(record);
         }
     }

--- a/datavec-api/src/test/java/org/datavec/api/split/InputSplitTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/InputSplitTests.java
@@ -15,6 +15,7 @@
  */
 package org.datavec.api.split;
 
+import com.google.common.io.Files;
 import org.datavec.api.io.filters.BalancedPathFilter;
 import org.datavec.api.io.filters.RandomPathFilter;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;
@@ -26,6 +27,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Random;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -50,7 +52,12 @@ public class InputSplitTests {
             }
 
             @Override
-            public boolean needsBootStrapForWrite() {
+            public void updateSplitLocations(boolean reset) {
+
+            }
+
+            @Override
+            public boolean needsBootstrapForWrite() {
                 return false;
             }
 
@@ -110,4 +117,15 @@ public class InputSplitTests {
         assertEquals(1, samples4[0].length());
         assertEquals(1, samples4[1].length());
     }
+
+
+    @Test
+    public void testFileSplitBootstrap() {
+        File tmpDir = Files.createTempDir();
+        FileSplit boostrap = new FileSplit(tmpDir);
+        assertTrue(boostrap.needsBootstrapForWrite());
+        boostrap.bootStrapForWrite();
+        assertTrue(tmpDir.listFiles() != null);
+    }
+
 }

--- a/datavec-api/src/test/java/org/datavec/api/split/InputSplitTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/InputSplitTests.java
@@ -21,10 +21,7 @@ import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.io.labels.PatternPathLabelGenerator;
 import org.junit.Test;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Random;
@@ -53,6 +50,21 @@ public class InputSplitTests {
             }
 
             @Override
+            public boolean needsBootStrapForWrite() {
+                return false;
+            }
+
+            @Override
+            public void bootStrapForWrite() {
+
+            }
+
+            @Override
+            public OutputStream openOutputStreamFor(String location) throws Exception {
+                return null;
+            }
+
+            @Override
             public InputStream openInputStreamFor(String location) throws Exception {
                 return null;
             }
@@ -67,11 +79,6 @@ public class InputSplitTests {
                 return true;
             }
 
-            @Override
-            public void write(DataOutput out) throws IOException {}
-
-            @Override
-            public void readFields(DataInput in) throws IOException {}
         };
 
         Random random = new Random(42);

--- a/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
@@ -1,0 +1,23 @@
+package org.datavec.api.split.parittion;
+
+import com.google.common.io.Files;
+import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
+import org.datavec.api.split.partition.Partitioner;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class PartitionerTests {
+    @Test
+    public void testRecordsPerFilePartition() {
+        Partitioner partitioner = new NumberOfRecordsPartitioner();
+        File tmpDir = Files.createTempDir();
+        FileSplit fileSplit = new FileSplit(tmpDir);
+        partitioner.init(fileSplit);
+        assertEquals(NumberOfRecordsPartitioner.DEFAULT_RECORDS_PER_FILE,partitioner.numPartitions());
+    }
+
+}

--- a/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class PartitionerTests {
@@ -16,8 +17,10 @@ public class PartitionerTests {
         Partitioner partitioner = new NumberOfRecordsPartitioner();
         File tmpDir = Files.createTempDir();
         FileSplit fileSplit = new FileSplit(tmpDir);
+        assertTrue(fileSplit.needsBootstrapForWrite());
+        fileSplit.bootStrapForWrite();
         partitioner.init(fileSplit);
-        assertEquals(NumberOfRecordsPartitioner.DEFAULT_RECORDS_PER_FILE,partitioner.numPartitions());
+        assertEquals(1,partitioner.numPartitions());
     }
 
 }

--- a/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
@@ -4,6 +4,7 @@ import com.google.common.io.Files;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.split.partition.Partitioner;
 import org.junit.Test;
 
@@ -36,13 +37,13 @@ public class PartitionerTests {
         Configuration configuration = new Configuration();
         configuration.set(NumberOfRecordsPartitioner.RECORDS_PER_FILE_CONFIG,String.valueOf(5));
         partitioner.init(configuration,fileSplit);
-        partitioner.updatePartitionInfo(5);
+        partitioner.updatePartitionInfo(PartitionMetaData.builder().numRecordsUpdated(5).build());
         assertTrue(partitioner.needsNewPartition());
         OutputStream os = partitioner.openNewStream();
         os.close();
         assertNotNull(os);
         //run more than once to ensure output stream creation works properly
-        partitioner.updatePartitionInfo(5);
+        partitioner.updatePartitionInfo(PartitionMetaData.builder().numRecordsUpdated(5).build());
         os = partitioner.openNewStream();
         os.close();
         assertNotNull(os);

--- a/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
+++ b/datavec-api/src/test/java/org/datavec/api/split/parittion/PartitionerTests.java
@@ -1,15 +1,18 @@
 package org.datavec.api.split.parittion;
 
 import com.google.common.io.Files;
+import org.datavec.api.conf.Configuration;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.split.partition.Partitioner;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.OutputStream;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PartitionerTests {
     @Test
@@ -21,6 +24,30 @@ public class PartitionerTests {
         fileSplit.bootStrapForWrite();
         partitioner.init(fileSplit);
         assertEquals(1,partitioner.numPartitions());
+    }
+
+    @Test
+    public void testInputAddFile() throws Exception {
+        Partitioner partitioner = new NumberOfRecordsPartitioner();
+        File tmpDir = Files.createTempDir();
+        FileSplit fileSplit = new FileSplit(tmpDir);
+        assertTrue(fileSplit.needsBootstrapForWrite());
+        fileSplit.bootStrapForWrite();
+        Configuration configuration = new Configuration();
+        configuration.set(NumberOfRecordsPartitioner.RECORDS_PER_FILE_CONFIG,String.valueOf(5));
+        partitioner.init(configuration,fileSplit);
+        partitioner.updatePartitionInfo(5);
+        assertTrue(partitioner.needsNewPartition());
+        OutputStream os = partitioner.openNewStream();
+        os.close();
+        assertNotNull(os);
+        //run more than once to ensure output stream creation works properly
+        partitioner.updatePartitionInfo(5);
+        os = partitioner.openNewStream();
+        os.close();
+        assertNotNull(os);
+
+
     }
 
 }

--- a/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowRecordReader.java
+++ b/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowRecordReader.java
@@ -66,8 +66,14 @@ public class ArrowRecordReader implements RecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
-        return next();
+    public List<List<Writable>> next(int num) {
+        List<List<Writable>> ret = new ArrayList<>(num);
+        int numBatches = 0;
+        while(hasNext() && numBatches < num) {
+            ret.add(next());
+        }
+
+        return ret;
     }
 
     @Override

--- a/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowRecordWriter.java
+++ b/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowRecordWriter.java
@@ -3,6 +3,7 @@ package org.datavec.arrow.recordreader;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.RecordWriter;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.Partitioner;
 import org.datavec.api.transform.schema.Schema;
 import org.datavec.api.writable.Writable;
 import org.datavec.arrow.ArrowConverter;
@@ -24,12 +25,12 @@ public class ArrowRecordWriter implements RecordWriter {
     }
 
     @Override
-    public void initialize(InputSplit inputSplit) throws Exception {
+    public void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception {
 
     }
 
     @Override
-    public void initialize(Configuration configuration, InputSplit split) throws Exception {
+    public void initialize(Configuration configuration, InputSplit split, Partitioner partitioner) throws Exception {
         setConf(configuration);
     }
 

--- a/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowRecordWriter.java
+++ b/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowRecordWriter.java
@@ -1,0 +1,74 @@
+package org.datavec.arrow.recordreader;
+
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.records.writer.RecordWriter;
+import org.datavec.api.split.InputSplit;
+import org.datavec.api.transform.schema.Schema;
+import org.datavec.api.writable.Writable;
+import org.datavec.arrow.ArrowConverter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.List;
+
+public class ArrowRecordWriter implements RecordWriter {
+
+    private Configuration configuration;
+    private Schema schema;
+    private OutputStream to;
+
+    public ArrowRecordWriter(Configuration configuration, Schema schema) {
+        this.configuration = configuration;
+        this.schema = schema;
+    }
+
+    @Override
+    public void initialize(InputSplit inputSplit) throws Exception {
+
+    }
+
+    @Override
+    public void initialize(Configuration configuration, InputSplit split) throws Exception {
+        setConf(configuration);
+    }
+
+    @Override
+    public void write(List<Writable> record) throws IOException {
+        writeBatch(Arrays.asList(record));
+    }
+
+    @Override
+    public void writeBatch(List<List<Writable>> batch) throws IOException {
+        if(batch instanceof ArrowWritableRecordBatch) {
+            ArrowWritableRecordBatch arrowWritableRecordBatch = (ArrowWritableRecordBatch) batch;
+
+        }
+        else {
+            ArrowConverter.writeRecordBatchTo(batch, schema, to);
+        }
+
+        to.flush();
+    }
+
+    @Override
+    public void close() {
+        if(to != null) {
+            try {
+                to.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+        this.configuration = conf;
+    }
+
+    @Override
+    public Configuration getConf() {
+        return configuration;
+    }
+}

--- a/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordBatch.java
+++ b/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordBatch.java
@@ -113,7 +113,7 @@ public class ArrowWritableRecordBatch implements List<List<Writable>>,Closeable 
 
     @Override
     public List<Writable> get(int i) {
-        List<Writable> ret = new ArrayList<>();
+        List<Writable> ret = new ArrayList<>(schema.numColumns());
         for(int column = 0; column < schema.numColumns(); column++) {
             ret.add(ArrowConverter.fromEntry(i,list.get(column),schema.getType(column)));
         }

--- a/datavec-arrow/src/test/java/org/datavec/arrow/ArrowConverterTest.java
+++ b/datavec-arrow/src/test/java/org/datavec/arrow/ArrowConverterTest.java
@@ -40,7 +40,7 @@ public class ArrowConverterTest {
     @Test
     public void testRecordWriter() throws Exception {
         Pair<Schema, List<List<Writable>>> schemaListPair = recordToWrite();
-        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(null,schemaListPair.getFirst());
+        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(schemaListPair.getFirst());
         arrowRecordWriter.writeBatch(schemaListPair.getRight());
     }
 

--- a/datavec-arrow/src/test/java/org/datavec/arrow/ArrowConverterTest.java
+++ b/datavec-arrow/src/test/java/org/datavec/arrow/ArrowConverterTest.java
@@ -20,6 +20,7 @@ import org.datavec.api.transform.schema.Schema;
 import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.Writable;
 import org.datavec.arrow.recordreader.ArrowRecordReader;
+import org.datavec.arrow.recordreader.ArrowRecordWriter;
 import org.datavec.arrow.recordreader.ArrowWritableRecordBatch;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -35,6 +36,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class ArrowConverterTest {
+
+    @Test
+    public void testRecordWriter() throws Exception {
+        Pair<Schema, List<List<Writable>>> schemaListPair = recordToWrite();
+        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(null,schemaListPair.getFirst());
+        arrowRecordWriter.writeBatch(schemaListPair.getRight());
+    }
 
     @Test
     public void testCreateNDArray() throws Exception {

--- a/datavec-arrow/src/test/java/org/datavec/arrow/RecordMapperTest.java
+++ b/datavec-arrow/src/test/java/org/datavec/arrow/RecordMapperTest.java
@@ -1,0 +1,74 @@
+package org.datavec.arrow;
+
+import org.apache.commons.io.FileUtils;
+import org.datavec.api.records.mapper.RecordMapper;
+import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
+import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
+import org.datavec.api.transform.schema.Schema;
+import org.datavec.api.writable.IntWritable;
+import org.datavec.api.writable.Writable;
+import org.datavec.arrow.recordreader.ArrowRecordReader;
+import org.datavec.arrow.recordreader.ArrowRecordWriter;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class RecordMapperTest {
+
+    @Test
+    public void testCopyFromCsvToArrow() throws Exception {
+        List<List<Writable>> list = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        int numColumns = 3;
+        for (int i = 0; i < 10; i++) {
+            List<Writable> temp = new ArrayList<>();
+            for (int j = 0; j < numColumns; j++) {
+                int v = 100 * i + j;
+                temp.add(new IntWritable(v));
+                sb.append(v);
+                if (j < 2)
+                    sb.append(",");
+                else if (i != 9)
+                    sb.append("\n");
+            }
+            list.add(temp);
+        }
+
+
+        Path p = Files.createTempFile("csvwritetest", ".csv");
+        FileUtils.write(p.toFile(),sb.toString());
+        p.toFile().deleteOnExit();
+
+        Schema.Builder schemaBuilder = new Schema.Builder();
+        for(int i = 0; i < numColumns; i++) {
+            schemaBuilder.addColumnInteger(String.valueOf(i));
+        }
+
+        CSVRecordReader recordReader = new CSVRecordReader();
+        FileSplit fileSplit = new FileSplit(p.toFile());
+
+        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(schemaBuilder.build());
+        File outputFile = Files.createTempFile("outputarrow","arrow").toFile();
+        FileSplit outputFileSplit = new FileSplit(outputFile);
+        RecordMapper mapper = RecordMapper.builder().batchSize(5).inputUrl(fileSplit)
+                .outputUrl(outputFileSplit).partitioner(new NumberOfRecordsPartitioner())
+                .recordReader(recordReader).recordWriter(arrowRecordWriter)
+                .build();
+        mapper.copy();
+
+        ArrowRecordReader arrowRecordReader = new ArrowRecordReader();
+        arrowRecordReader.initialize(outputFileSplit);
+        List<List<Writable>> next = arrowRecordReader.next(10);
+        System.out.println(next);
+        assertEquals(10,next.size());
+
+    }
+
+}

--- a/datavec-arrow/src/test/java/org/datavec/arrow/RecordMapperTest.java
+++ b/datavec-arrow/src/test/java/org/datavec/arrow/RecordMapperTest.java
@@ -1,8 +1,10 @@
 package org.datavec.arrow;
 
+import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.datavec.api.records.mapper.RecordMapper;
 import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
+import org.datavec.api.records.writer.impl.csv.CSVRecordWriter;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
 import org.datavec.api.transform.schema.Schema;
@@ -11,6 +13,7 @@ import org.datavec.api.writable.Writable;
 import org.datavec.arrow.recordreader.ArrowRecordReader;
 import org.datavec.arrow.recordreader.ArrowRecordWriter;
 import org.junit.Test;
+import org.nd4j.linalg.primitives.Triple;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -23,7 +26,75 @@ import static org.junit.Assert.assertEquals;
 public class RecordMapperTest {
 
     @Test
+    public void testCopyFromArrowToCsv() throws Exception {
+        val recordsPair = records();
+
+        Path p = Files.createTempFile("arrowwritetest", ".arrow");
+        FileUtils.write(p.toFile(),recordsPair.getFirst());
+        p.toFile().deleteOnExit();
+
+        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(recordsPair.getMiddle());
+        FileSplit split = new FileSplit(p.toFile());
+        arrowRecordWriter.initialize(split,new NumberOfRecordsPartitioner());
+        arrowRecordWriter.writeBatch(recordsPair.getRight());
+
+
+        ArrowRecordReader arrowRecordReader = new ArrowRecordReader();
+        arrowRecordReader.initialize(split);
+
+
+        CSVRecordWriter csvRecordWriter = new CSVRecordWriter();
+        Path p2 = Files.createTempFile("arrowwritetest", ".csv");
+        FileUtils.write(p2.toFile(),recordsPair.getFirst());
+        p.toFile().deleteOnExit();
+        FileSplit outputCsv = new FileSplit(p2.toFile());
+
+        RecordMapper mapper = RecordMapper.builder().batchSize(10).inputUrl(split)
+                .outputUrl(outputCsv)
+                .partitioner(new NumberOfRecordsPartitioner())
+                .recordReader(arrowRecordReader).recordWriter(csvRecordWriter)
+                .build();
+        mapper.copy();
+
+        CSVRecordReader recordReader = new CSVRecordReader();
+        recordReader.initialize(outputCsv);
+
+
+        List<List<Writable>> loadedCSvRecords = recordReader.next(10);
+        assertEquals(10,loadedCSvRecords.size());
+    }
+
+
+    @Test
     public void testCopyFromCsvToArrow() throws Exception {
+        val recordsPair = records();
+
+        Path p = Files.createTempFile("csvwritetest", ".csv");
+        FileUtils.write(p.toFile(),recordsPair.getFirst());
+        p.toFile().deleteOnExit();
+
+
+        CSVRecordReader recordReader = new CSVRecordReader();
+        FileSplit fileSplit = new FileSplit(p.toFile());
+
+        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(recordsPair.getMiddle());
+        File outputFile = Files.createTempFile("outputarrow","arrow").toFile();
+        FileSplit outputFileSplit = new FileSplit(outputFile);
+        RecordMapper mapper = RecordMapper.builder().batchSize(5).inputUrl(fileSplit)
+                .outputUrl(outputFileSplit).partitioner(new NumberOfRecordsPartitioner())
+                .recordReader(recordReader).recordWriter(arrowRecordWriter)
+                .build();
+        mapper.copy();
+
+        ArrowRecordReader arrowRecordReader = new ArrowRecordReader();
+        arrowRecordReader.initialize(outputFileSplit);
+        List<List<Writable>> next = arrowRecordReader.next(10);
+        System.out.println(next);
+        assertEquals(10,next.size());
+
+    }
+
+    private Triple<String,Schema,List<List<Writable>>> records() {
         List<List<Writable>> list = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         int numColumns = 3;
@@ -42,33 +113,13 @@ public class RecordMapperTest {
         }
 
 
-        Path p = Files.createTempFile("csvwritetest", ".csv");
-        FileUtils.write(p.toFile(),sb.toString());
-        p.toFile().deleteOnExit();
-
         Schema.Builder schemaBuilder = new Schema.Builder();
         for(int i = 0; i < numColumns; i++) {
             schemaBuilder.addColumnInteger(String.valueOf(i));
         }
 
-        CSVRecordReader recordReader = new CSVRecordReader();
-        FileSplit fileSplit = new FileSplit(p.toFile());
-
-        ArrowRecordWriter arrowRecordWriter = new ArrowRecordWriter(schemaBuilder.build());
-        File outputFile = Files.createTempFile("outputarrow","arrow").toFile();
-        FileSplit outputFileSplit = new FileSplit(outputFile);
-        RecordMapper mapper = RecordMapper.builder().batchSize(5).inputUrl(fileSplit)
-                .outputUrl(outputFileSplit).partitioner(new NumberOfRecordsPartitioner())
-                .recordReader(recordReader).recordWriter(arrowRecordWriter)
-                .build();
-        mapper.copy();
-
-        ArrowRecordReader arrowRecordReader = new ArrowRecordReader();
-        arrowRecordReader.initialize(outputFileSplit);
-        List<List<Writable>> next = arrowRecordReader.next(10);
-        System.out.println(next);
-        assertEquals(10,next.size());
-
+        return Triple.of(sb.toString(),schemaBuilder.build(),list);
     }
+
 
 }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -250,7 +250,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         Preconditions.checkArgument(num > 0, "Number of examples must be > 0: got " + num);
 
         if (imageLoader == null) {

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/ObjectDetectionRecordReader.java
@@ -139,7 +139,7 @@ public class ObjectDetectionRecordReader extends BaseImageRecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         List<File> files = new ArrayList<>(num);
         List<List<ImageObject>> objects = new ArrayList<>(num);
 

--- a/datavec-excel/src/main/java/org/datavec/poi/excel/ExcelRecordWriter.java
+++ b/datavec-excel/src/main/java/org/datavec/poi/excel/ExcelRecordWriter.java
@@ -1,0 +1,157 @@
+package org.datavec.poi.excel;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.datavec.api.conf.Configuration;
+import org.datavec.api.records.writer.impl.FileRecordWriter;
+import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.PartitionMetaData;
+import org.datavec.api.split.partition.Partitioner;
+import org.datavec.api.writable.*;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class ExcelRecordWriter extends FileRecordWriter {
+
+    public final static String WORKSHEET_NAME = "org.datavec.poi.excel.worksheet.name";
+    public final static String FILE_TYPE = "org.datavec.poi.excel.type";
+
+
+    public final static String DEFAULT_FILE_TYPE = "xlsx";
+    public final static String DEFAULT_WORKSHEET_NAME = "datavec-worksheet";
+
+
+    private String workBookName = DEFAULT_WORKSHEET_NAME;
+    private String fileTypeToUse = DEFAULT_FILE_TYPE;
+
+    private Sheet sheet;
+    private Workbook workbook;
+
+
+
+    private void createRow(int rowNum,int numCols,List<Writable> value) {
+        // Create a Row
+        Row headerRow = sheet.createRow(rowNum);
+        int col = 0;
+        for(Writable writable : value) {
+            // Creating cells
+            Cell cell = headerRow.createCell(col++);
+            setValueForCell(cell,writable);
+
+
+        }
+
+        // Resize all columns to fit the content size
+        for(int i = 0; i < numCols; i++) {
+            sheet.autoSizeColumn(i);
+        }
+    }
+
+    private void setValueForCell(Cell cell,Writable value) {
+        if(value instanceof DoubleWritable || value instanceof LongWritable || value instanceof FloatWritable || value instanceof IntWritable) {
+            cell.setCellValue(value.toDouble());
+        }
+        else if(value instanceof BooleanWritable) {
+            cell.setCellValue(((BooleanWritable) value).get());
+        }
+        else if(value instanceof Text) {
+            cell.setCellValue(value.toString());
+        }
+
+    }
+
+
+    @Override
+    public boolean supportsBatch() {
+        return true;
+    }
+
+    @Override
+    public void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception {
+        this.conf = new Configuration();
+        this.partitioner = partitioner;
+        partitioner.init(inputSplit);
+        out = new DataOutputStream(partitioner.currentOutputStream());
+        initPoi();
+
+
+    }
+
+    private void initPoi()  {
+        if(fileTypeToUse.equals("xlsx"))
+            workbook = new XSSFWorkbook();
+        else {
+            //xls
+            workbook = new HSSFWorkbook();
+        }
+
+        this.sheet = workbook.createSheet(workBookName);
+
+
+    }
+
+    @Override
+    public void initialize(Configuration configuration, InputSplit split, Partitioner partitioner) throws Exception {
+        this.workBookName = configuration.get(WORKSHEET_NAME,DEFAULT_WORKSHEET_NAME);
+        this.fileTypeToUse = configuration.get(FILE_TYPE,DEFAULT_FILE_TYPE);
+        this.conf = configuration;
+        partitioner.init(split);
+        out = new DataOutputStream(partitioner.currentOutputStream());
+        initPoi();
+    }
+
+    @Override
+    public PartitionMetaData write(List<Writable> record) throws IOException {
+        createRow(partitioner.numRecordsWritten(),record.size(),record);
+        reinitIfNecessary();
+        return PartitionMetaData.builder().numRecordsUpdated(1).build();
+    }
+
+    @Override
+    public PartitionMetaData writeBatch(List<List<Writable>> batch) throws IOException {
+        int numSoFar = 0;
+        for (List<Writable> record : batch) {
+            createRow(partitioner.numRecordsWritten() + numSoFar, record.size(), record);
+            reinitIfNecessary();
+            numSoFar++;
+        }
+
+        return PartitionMetaData.builder().numRecordsUpdated(batch.size()).build();
+    }
+
+    private void reinitIfNecessary() throws IOException {
+        if(partitioner.needsNewPartition()) {
+            workbook.write(out);
+            out.flush();
+            out.close();
+            workbook.close();
+            initPoi();
+            this.out = new DataOutputStream(partitioner.openNewStream());
+        }
+    }
+
+    @Override
+    public void close() {
+        if(workbook != null) {
+            try {
+                if(out != null) {
+                    workbook.write(out);
+                    out.flush();
+                    out.close();
+                }
+
+                workbook.close();
+
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+}

--- a/datavec-excel/src/test/java/org/datavec/poi/excel/ExcelRecordWriterTest.java
+++ b/datavec-excel/src/test/java/org/datavec/poi/excel/ExcelRecordWriterTest.java
@@ -1,0 +1,68 @@
+package org.datavec.poi.excel;
+
+import lombok.val;
+import org.datavec.api.split.FileSplit;
+import org.datavec.api.split.partition.NumberOfRecordsPartitioner;
+import org.datavec.api.transform.schema.Schema;
+import org.datavec.api.writable.IntWritable;
+import org.datavec.api.writable.Writable;
+import org.junit.Test;
+import org.nd4j.linalg.primitives.Triple;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExcelRecordWriterTest {
+
+    @Test
+    public void testWriter() throws Exception  {
+        ExcelRecordWriter excelRecordWriter = new ExcelRecordWriter();
+        val records = records();
+        File tmpDir = Files.createTempDirectory("testexcel").toFile();
+        File outputFile = new File(tmpDir,"testexcel.xlsx");
+        outputFile.deleteOnExit();
+        FileSplit fileSplit = new FileSplit(outputFile);
+        excelRecordWriter.initialize(fileSplit,new NumberOfRecordsPartitioner());
+        excelRecordWriter.writeBatch(records.getRight());
+        excelRecordWriter.close();
+        File parentFile = outputFile.getParentFile();
+        assertEquals(1,parentFile.list().length);
+
+        ExcelRecordReader excelRecordReader = new ExcelRecordReader();
+        excelRecordReader.initialize(fileSplit);
+        List<List<Writable>> next = excelRecordReader.next(10);
+        assertEquals(10,next.size());
+
+    }
+
+    private Triple<String,Schema,List<List<Writable>>> records() {
+        List<List<Writable>> list = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        int numColumns = 3;
+        for (int i = 0; i < 10; i++) {
+            List<Writable> temp = new ArrayList<>();
+            for (int j = 0; j < numColumns; j++) {
+                int v = 100 * i + j;
+                temp.add(new IntWritable(v));
+                sb.append(v);
+                if (j < 2)
+                    sb.append(",");
+                else if (i != 9)
+                    sb.append("\n");
+            }
+            list.add(temp);
+        }
+
+
+        Schema.Builder schemaBuilder = new Schema.Builder();
+        for(int i = 0; i < numColumns; i++) {
+            schemaBuilder.addColumnInteger(String.valueOf(i));
+        }
+
+        return Triple.of(sb.toString(),schemaBuilder.build(),list);
+    }
+}

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileRecordReader.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileRecordReader.java
@@ -185,7 +185,7 @@ public class MapFileRecordReader implements RecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileSequenceRecordReader.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/reader/mapfile/MapFileSequenceRecordReader.java
@@ -254,7 +254,7 @@ public class MapFileSequenceRecordReader implements SequenceRecordReader {
     }
 
     @Override
-    public List<Writable> next(int num) {
+    public List<List<Writable>> next(int num) {
         throw new UnsupportedOperationException();
     }
 

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/AbstractMapFileWriter.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/AbstractMapFileWriter.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.io.MapFile;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.WritableComparable;
 import org.datavec.api.conf.Configuration;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.writable.*;
 
 import java.io.File;
@@ -230,7 +231,7 @@ public abstract class AbstractMapFileWriter<T> {
         return newList;
     }
 
-    public void write(T record) throws IOException {
+    public PartitionMetaData write(T record) throws IOException {
         if (isClosed.get()) {
             throw new UnsupportedOperationException("Cannot write to MapFileRecordReader that has already been closed");
         }
@@ -260,6 +261,8 @@ public abstract class AbstractMapFileWriter<T> {
         org.apache.hadoop.io.Writable hadoopWritable = getHadoopWritable(record);
 
         w.append(new org.apache.hadoop.io.LongWritable(key), hadoopWritable);
+
+        return PartitionMetaData.builder().numRecordsUpdated(1).build();
     }
 
 

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/MapFileRecordWriter.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/MapFileRecordWriter.java
@@ -20,6 +20,7 @@ import lombok.NonNull;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.RecordWriter;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.Partitioner;
 import org.datavec.api.writable.Writable;
 import org.datavec.api.writable.WritableType;
 import org.datavec.hadoop.records.reader.mapfile.record.RecordWritable;
@@ -158,12 +159,12 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
     }
 
     @Override
-    public void initialize(InputSplit inputSplit) throws Exception {
-        
+    public void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception {
+
     }
 
     @Override
-    public void initialize(Configuration configuration, InputSplit split) throws Exception {
+    public void initialize(Configuration configuration, InputSplit split, Partitioner partitioner) throws Exception {
 
     }
 

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/MapFileRecordWriter.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/MapFileRecordWriter.java
@@ -17,12 +17,15 @@
 package org.datavec.hadoop.records.writer.mapfile;
 
 import lombok.NonNull;
+import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.RecordWriter;
+import org.datavec.api.split.InputSplit;
 import org.datavec.api.writable.Writable;
 import org.datavec.api.writable.WritableType;
 import org.datavec.hadoop.records.reader.mapfile.record.RecordWritable;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -152,5 +155,20 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
         }
 
         return new RecordWritable(input);
+    }
+
+    @Override
+    public void initialize(InputSplit inputSplit) throws Exception {
+        
+    }
+
+    @Override
+    public void initialize(Configuration configuration, InputSplit split) throws Exception {
+
+    }
+
+    @Override
+    public void writeBatch(List<List<Writable>> batch) throws IOException {
+
     }
 }

--- a/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/MapFileRecordWriter.java
+++ b/datavec-hadoop/src/main/java/org/datavec/hadoop/records/writer/mapfile/MapFileRecordWriter.java
@@ -20,6 +20,7 @@ import lombok.NonNull;
 import org.datavec.api.conf.Configuration;
 import org.datavec.api.records.writer.RecordWriter;
 import org.datavec.api.split.InputSplit;
+import org.datavec.api.split.partition.PartitionMetaData;
 import org.datavec.api.split.partition.Partitioner;
 import org.datavec.api.writable.Writable;
 import org.datavec.api.writable.WritableType;
@@ -102,7 +103,7 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
      * @param hadoopConfiguration Hadoop configuration.
      */
     public MapFileRecordWriter(@NonNull File outputDir, int mapFileSplitSize, WritableType convertTextTo,
-                                       org.apache.hadoop.conf.Configuration hadoopConfiguration) {
+                               org.apache.hadoop.conf.Configuration hadoopConfiguration) {
         super(outputDir, mapFileSplitSize, convertTextTo, DEFAULT_INDEX_INTERVAL, hadoopConfiguration);
     }
 
@@ -120,7 +121,7 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
      * @param hadoopConfiguration Hadoop configuration.
      */
     public MapFileRecordWriter(@NonNull File outputDir, int mapFileSplitSize, WritableType convertTextTo,
-                                       int indexInterval, org.apache.hadoop.conf.Configuration hadoopConfiguration) {
+                               int indexInterval, org.apache.hadoop.conf.Configuration hadoopConfiguration) {
         super(outputDir, mapFileSplitSize, convertTextTo, indexInterval, hadoopConfiguration);
     }
 
@@ -139,8 +140,8 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
      * @param hadoopConfiguration Hadoop configuration.
      */
     public MapFileRecordWriter(@NonNull File outputDir, int mapFileSplitSize, WritableType convertTextTo,
-                                       int indexInterval, String filenamePattern,
-                                       org.apache.hadoop.conf.Configuration hadoopConfiguration) {
+                               int indexInterval, String filenamePattern,
+                               org.apache.hadoop.conf.Configuration hadoopConfiguration) {
         super(outputDir, mapFileSplitSize, convertTextTo, indexInterval, filenamePattern, hadoopConfiguration);
     }
 
@@ -159,6 +160,11 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
     }
 
     @Override
+    public boolean supportsBatch() {
+        return false;
+    }
+
+    @Override
     public void initialize(InputSplit inputSplit, Partitioner partitioner) throws Exception {
 
     }
@@ -169,7 +175,7 @@ public class MapFileRecordWriter extends AbstractMapFileWriter<List<Writable>> i
     }
 
     @Override
-    public void writeBatch(List<List<Writable>> batch) throws IOException {
-
+    public PartitionMetaData writeBatch(List<List<Writable>> batch) throws IOException {
+        return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-codec.version>1.10</commons-codec.version>
         <args4j.version>2.0.29</args4j.version>
-        <lombok.version>1.16.10</lombok.version>
+        <lombok.version>1.16.18</lombok.version>
         <jodatime.version>2.9.2</jodatime.version>
         <freemarker.version>2.3.23</freemarker.version>
         <logback.version>1.1.2</logback.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Clean up input split interface, no longer extending Writable.
Add bootstrapping concept to input splits, this allows usage of input splits
with RecordWriters.
Add Partitioner for allowing partition of writes to 1 or more files and output streams.
Allow record writers to use configurations and input splits.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
