### PR TITLE
Additional tests for arrow sequence functionality

### DIFF
--- a/datavec-arrow/src/test/java/org/datavec/arrow/ArrowConverterTest.java
+++ b/datavec-arrow/src/test/java/org/datavec/arrow/ArrowConverterTest.java
@@ -25,6 +25,7 @@ import org.datavec.arrow.recordreader.ArrowRecordWriter;
 import org.datavec.arrow.recordreader.ArrowWritableRecordBatch;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.Pair;
 
 import java.io.*;
@@ -91,9 +92,16 @@ public class ArrowConverterTest {
         assertEquals(3,fieldVectors.size());
         assertEquals(5,fieldVectors.get(0).getValueCount());
 
+        //Convert to ArrowWritableRecordBatch - note we can't do this in general with time series...
         ArrowWritableRecordBatch wri = ArrowConverter.toArrowWritables(fieldVectors, schema.build());
         INDArray arr = ArrowConverter.toArray(wri);
         assertArrayEquals(new int[] {5,3}, arr.shape());
+
+        INDArray exp = Nd4j.create(5, 3);
+        for( int i=0; i<5; i++ ){
+            exp.getRow(i).assign(i);
+        }
+        assertEquals(exp, arr);
     }
 
     @Test

--- a/datavec-arrow/src/test/java/org/datavec/arrow/recordreader/ArrowWritableRecordTimeSeriesBatchTests.java
+++ b/datavec-arrow/src/test/java/org/datavec/arrow/recordreader/ArrowWritableRecordTimeSeriesBatchTests.java
@@ -4,7 +4,9 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.datavec.api.transform.schema.Schema;
+import org.datavec.api.writable.DoubleWritable;
 import org.datavec.api.writable.IntWritable;
+import org.datavec.api.writable.Text;
 import org.datavec.api.writable.Writable;
 import org.datavec.arrow.ArrowConverter;
 import org.junit.Test;
@@ -50,7 +52,35 @@ public class ArrowWritableRecordTimeSeriesBatchTests {
         }
         ArrowWritableRecordTimeSeriesBatch arrowWritableRecordTimeSeriesBatch = new ArrowWritableRecordTimeSeriesBatch(fieldVectors,schema.build(),timeStep.size() * timeStep.get(0).size());
         assertEquals(timeSteps,arrowWritableRecordTimeSeriesBatch.toArrayList());
-
     }
 
+    @Test
+    public void testVariableLengthTS() {
+        Schema.Builder schema = new Schema.Builder()
+                .addColumnString("str")
+                .addColumnInteger("int")
+                .addColumnDouble("dbl");
+
+        List<List<Writable>> firstSeq = Arrays.asList(
+                Arrays.<Writable>asList(new Text("00"),new IntWritable(0),new DoubleWritable(2.0)),
+                Arrays.<Writable>asList(new Text("01"),new IntWritable(1),new DoubleWritable(2.1)),
+                Arrays.<Writable>asList(new Text("02"),new IntWritable(2),new DoubleWritable(2.2)));
+
+        List<List<Writable>> secondSeq = Arrays.asList(
+                Arrays.<Writable>asList(new Text("10"),new IntWritable(10),new DoubleWritable(12.0)),
+                Arrays.<Writable>asList(new Text("11"),new IntWritable(11),new DoubleWritable(12.1)));
+
+        List<List<List<Writable>>> sequences = Arrays.asList(firstSeq, secondSeq);
+
+
+        List<FieldVector> fieldVectors = ArrowConverter.toArrowColumnsTimeSeries(bufferAllocator, schema.build(), sequences);
+        assertEquals(3,fieldVectors.size());
+
+        int timeSeriesStride = -1;  //Can't sequences of different length...
+        ArrowWritableRecordTimeSeriesBatch arrowWritableRecordTimeSeriesBatch
+                = new ArrowWritableRecordTimeSeriesBatch(fieldVectors,schema.build(),timeSeriesStride);
+
+        List<List<List<Writable>>> asList = arrowWritableRecordTimeSeriesBatch.toArrayList();
+        assertEquals(sequences, asList);
+    }
 }


### PR DESCRIPTION
Improves testArrowColumnsStringTimeSeries() - NOT passing currently.

Adds ArrowWritableRecordTimeSeriesBatchTests.testVariableLengthTS() - was implemented assuming variable length time series were supported, but isn't really applicable unless that holds.