### PR TITLE
Make lombok artifact optional in pom.xml files

### DIFF
--- a/datavec-api/pom.xml
+++ b/datavec-api/pom.xml
@@ -77,12 +77,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>${freemarker.version}</version>

--- a/datavec-spark-inference-parent/datavec-spark-inference-model/pom.xml
+++ b/datavec-spark-inference-parent/datavec-spark-inference-model/pom.xml
@@ -20,11 +20,6 @@
             <version>${nd4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.datavec</groupId>
             <artifactId>datavec-api</artifactId>
             <version>${project.parent.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-codec.version>1.10</commons-codec.version>
         <args4j.version>2.0.29</args4j.version>
-        <lombok.version>1.16.18</lombok.version>
+        <lombok.version>1.16.20</lombok.version>
         <jodatime.version>2.9.2</jodatime.version>
         <freemarker.version>2.3.23</freemarker.version>
         <logback.version>1.1.2</logback.version>
@@ -698,6 +698,12 @@
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/4839

## What changes were proposed in this pull request?

Prevent Lombok from leaking to dependent projects, update version, and rearrange dependencies as required because no longer transitive.

## How was this patch tested?

Build passes, running LenetMnistExample from dl4j-examples works, and confirmed manually on it that `mvn dependency:tree` does not contain lombok anymore.