### PR TITLE
#553 Fix OR file size checking in windows

### DIFF
--- a/datavec-api/src/test/java/org/datavec/api/util/ClassPathResourceTest.java
+++ b/datavec-api/src/test/java/org/datavec/api/util/ClassPathResourceTest.java
@@ -26,6 +26,9 @@ import java.io.InputStreamReader;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.AnyOf.anyOf;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * @author raver119@gmail.com
@@ -48,7 +51,7 @@ public class ClassPathResourceTest {
 
         assertTrue(intFile.exists());
         if (isWindows) {
-            assertEquals(2850, intFile.length());
+            assertThat(intFile.length(), anyOf(equalTo(2700L), equalTo(2850L)));
         } else {
             assertEquals(2700, intFile.length());
         }
@@ -60,7 +63,7 @@ public class ClassPathResourceTest {
 
         assertTrue(intFile.exists());
         if (isWindows) {
-            assertEquals(2850, intFile.length());
+            assertThat(intFile.length(), anyOf(equalTo(2700L), equalTo(2850L)));
         } else {
             assertEquals(2700, intFile.length());
         }
@@ -73,7 +76,7 @@ public class ClassPathResourceTest {
         assertTrue(intFile.exists());
 
         if (isWindows) {
-            assertEquals(64, intFile.length());
+            assertThat(intFile.length(), anyOf(equalTo(60L), equalTo(64L)));
         } else {
             assertEquals(60, intFile.length());
         }
@@ -85,7 +88,7 @@ public class ClassPathResourceTest {
         File intFile = resource.getFile();
 
         if (isWindows) {
-            assertEquals(64, intFile.length());
+            assertThat(intFile.length(), anyOf(equalTo(60L), equalTo(64L)));
         } else {
             assertEquals(60, intFile.length());
         }
@@ -107,7 +110,7 @@ public class ClassPathResourceTest {
         File intFile = resource.getFile();
 
         if (isWindows) {
-            assertEquals(64, intFile.length());
+            assertThat(intFile.length(), anyOf(equalTo(60L), equalTo(64L)));
         } else {
             assertEquals(60, intFile.length());
         }

--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -150,7 +150,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
 
     @Override
     public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
-        this.appendLabel = conf.getBoolean(APPEND_LABEL, false);
+        this.appendLabel = conf.getBoolean(APPEND_LABEL, appendLabel);
         this.labels = new ArrayList<>(conf.getStringCollection(LABELS));
         this.height = conf.getInt(HEIGHT, height);
         this.width = conf.getInt(WIDTH, width);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to support different types of cloning in Windows, the assertion accepts any of the two values. The risk for a letting pass an error are too small in that case.

## How was this patch tested?

This is a fix in the unit tests themselves
