### PR TITLE
#555 value for appendLabel is the already defined one by default

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/BaseImageRecordReader.java
@@ -150,7 +150,7 @@ public abstract class BaseImageRecordReader extends BaseRecordReader {
 
     @Override
     public void initialize(Configuration conf, InputSplit split) throws IOException, InterruptedException {
-        this.appendLabel = conf.getBoolean(APPEND_LABEL, false);
+        this.appendLabel = conf.getBoolean(APPEND_LABEL, appendLabel);
         this.labels = new ArrayList<>(conf.getStringCollection(LABELS));
         this.height = conf.getInt(HEIGHT, height);
         this.width = conf.getInt(WIDTH, width);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for #555. Value for appendLabel is the already defined one by default. So if the configuration does not define a value the already defined value (at instantiation for example).
I think the correction is too simple for a test case.