### PR TITLE
ImageLoader: toBufferedImageRGB fix

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/ImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/ImageLoader.java
@@ -399,14 +399,14 @@ public class ImageLoader extends BaseImageLoader {
             throw new IllegalArgumentException("Arr must be 3d");
 
         image = scalingIfNeed(image, arr.size(-2), arr.size(-1), true);
-        for (int i = 0; i < image.getWidth(); i++) {
-            for (int j = 0; j < image.getHeight(); j++) {
-                int r = arr.slice(0).getInt(i, j);
+        for (int i = 0; i < image.getHeight(); i++) {
+            for (int j = 0; j < image.getWidth(); j++) {
+                int r = arr.slice(2).getInt(i, j);
                 int g = arr.slice(1).getInt(i, j);
-                int b = arr.slice(2).getInt(i, j);
+                int b = arr.slice(0).getInt(i, j);
                 int a = 1;
                 int col = (a << 24) | (r << 16) | (g << 8) | b;
-                image.setRGB(i, j, col);
+                image.setRGB(j, i, col);
             }
         }
     }

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestImageLoader.java
@@ -128,6 +128,28 @@ public class TestImageLoader {
 
     }
 
+    @Test
+    public void testToBufferedImageRGB() {
+        BufferedImage img = makeRandomBufferedImage(false);
+        int w = img.getWidth();
+        int h = img.getHeight();
+        int ch = 3;
+
+        ImageLoader loader = new ImageLoader(0, 0, ch);
+        INDArray arr = loader.toINDArrayBGR(img);
+        BufferedImage img2 = new BufferedImage(w, h, BufferedImage.TYPE_3BYTE_BGR);
+        loader.toBufferedImageRGB(arr, img2);
+
+        for (int i = 0; i < h; ++i) {
+            for (int j = 0; j < w; ++j) {
+                int srcColor = img.getRGB(j, i);
+                int restoredColor = img2.getRGB(j, i);
+                assertEquals(srcColor, restoredColor);
+            }
+        }
+
+    }
+
     private BufferedImage makeRandomBufferedImage(boolean alpha) {
         int w = rng.nextInt() % 100 + 100;
         int h = rng.nextInt() % 100 + 100;


### PR DESCRIPTION
## What changes were proposed in this pull request?
toBufferedImageRGB in origin, worked only with square dimensions (w == h), and create distorted image with flipped pixels and colors

![image](https://user-images.githubusercontent.com/3922262/38782378-29448b4a-40fb-11e8-8205-308bef454802.png)


## How was this patch tested?

tested by hands and with unit test, proposed in this pull request

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
