### PR TITLE
#571 NativeImageLoader buffer reuse

### DIFF
--- a/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -214,7 +214,7 @@ public class NativeImageLoader extends BaseImageLoader {
 
         Mat image = imdecode(mat, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
         if (image == null || image.empty()) {
-            PIX pix = pixReadMem(bytes, bytes.length);
+            PIX pix = pixReadMem(bytes, length);
             if (pix == null) {
                 throw new IOException("Could not decode image from input stream");
             }
@@ -227,9 +227,9 @@ public class NativeImageLoader extends BaseImageLoader {
     }
 
     /**
-     * Read the stream to the buffer, and return the number of
-     * @param is
-     * @return
+     * Read the stream to the buffer, and return the number of bytes read
+     * @param is Input stream to read
+     * @return   Pair with the buffer, and the number of bytes read
      * @throws IOException
      */
     private Pair<byte[],Integer> streamToBuffer(InputStream is) throws IOException {
@@ -279,10 +279,16 @@ public class NativeImageLoader extends BaseImageLoader {
 
     @Override
     public Image asImageMatrix(InputStream is) throws IOException {
-        byte[] bytes = IOUtils.toByteArray(is);
-        Mat image = imdecode(new Mat(bytes), CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
+        Pair<byte[],Integer> pair = streamToBuffer(is);
+        byte[] bytes = pair.getFirst();
+        int length = pair.getSecond();
+        BytePointer bp = new BytePointer(length);
+        bp.put(bytes, 0, length);
+        Mat mat = new Mat(bp, false);
+
+        Mat image = imdecode(mat, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
         if (image == null || image.empty()) {
-            PIX pix = pixReadMem(bytes, bytes.length);
+            PIX pix = pixReadMem(bytes, length);
             if (pix == null) {
                 throw new IOException("Could not decode image from input stream");
             }
@@ -451,10 +457,16 @@ public class NativeImageLoader extends BaseImageLoader {
     }
 
     public void asMatrixView(InputStream is, INDArray view) throws IOException {
-        byte[] bytes = IOUtils.toByteArray(is);
-        Mat image = imdecode(new Mat(bytes), CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
+        Pair<byte[],Integer> pair = streamToBuffer(is);
+        byte[] bytes = pair.getFirst();
+        int length = pair.getSecond();
+        BytePointer bp = new BytePointer(length);
+        bp.put(bytes, 0, length);
+        Mat mat = new Mat(bp, false);
+
+        Mat image = imdecode(mat, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
         if (image == null || image.empty()) {
-            PIX pix = pixReadMem(bytes, bytes.length);
+            PIX pix = pixReadMem(bytes, length);
             if (pix == null) {
                 throw new IOException("Could not decode image from input stream");
             }
@@ -612,10 +624,15 @@ public class NativeImageLoader extends BaseImageLoader {
      */
     public ImageWritable asWritable(File f) throws IOException {
         try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(f))) {
-            byte[] bytes = IOUtils.toByteArray(bis);
-            Mat image = imdecode(new Mat(bytes), CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
+            Pair<byte[],Integer> pair = streamToBuffer(bis);
+            byte[] bytes = pair.getFirst();
+            int length = pair.getSecond();
+            BytePointer bp = new BytePointer(length);
+            bp.put(bytes, 0, length);
+            Mat mat = new Mat(bp, false);
+            Mat image = imdecode(mat, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_ANYCOLOR);
             if (image == null || image.empty()) {
-                PIX pix = pixReadMem(bytes, bytes.length);
+                PIX pix = pixReadMem(bytes, length);
                 if (pix == null) {
                     throw new IOException("Could not decode image from input stream");
                 }

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -314,16 +314,20 @@ public class TestNativeImageLoader {
     @Test
     public void testBufferRealloc() throws Exception {
         Field f = NativeImageLoader.class.getDeclaredField("buffer");
+        Field m = NativeImageLoader.class.getDeclaredField("bufferMat");
         f.setAccessible(true);
+        m.setAccessible(true);
 
         File f1 = new ClassPathResource("voc/2007/JPEGImages/000005.jpg").getFile();
         File f2 = new ClassPathResource("voc/2007/JPEGImages/000007.jpg").getFile();
 
         //Start with a large buffer
         byte[] buffer = new byte[20*1024*1024];
+        Mat bufferMat = new Mat(buffer);
 
         NativeImageLoader loader = new NativeImageLoader(28, 28, 1);
         f.set(loader, buffer);
+        m.set(loader, bufferMat);
 
         INDArray img1LargeBuffer = loader.asMatrix(f1);
         INDArray img2LargeBuffer = loader.asMatrix(f2);
@@ -352,13 +356,16 @@ public class TestNativeImageLoader {
 
         //Assign much too small buffer:
         buffer = new byte[10];
+        bufferMat = new Mat(buffer);
         f.set(loader, buffer);
+        m.set(loader, bufferMat);
         INDArray img1SmallBuffer1 = loader.asMatrix(f1);
         INDArray img1SmallBuffer2 = loader.asMatrix(f1);
         assertEquals(img1LargeBuffer, img1SmallBuffer1);
         assertEquals(img1LargeBuffer, img1SmallBuffer2);
 
         f.set(loader, buffer);
+        m.set(loader, bufferMat);
         INDArray img2SmallBuffer1 = loader.asMatrix(f2);
         INDArray img2SmallBuffer2 = loader.asMatrix(f2);
         assertEquals(img2LargeBuffer, img2SmallBuffer1);
@@ -368,8 +375,10 @@ public class TestNativeImageLoader {
         try(InputStream is = new FileInputStream(f1)){
             byte[] temp = IOUtils.toByteArray(is);
             buffer = new byte[temp.length];
+            bufferMat = new Mat(buffer);
         }
         f.set(loader, buffer);
+        m.set(loader, bufferMat);
 
         INDArray img1ExactBuffer = loader.asMatrix(f1);
         assertEquals(img1LargeBuffer, img1ExactBuffer);

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -15,17 +15,22 @@
  */
 package org.datavec.image.loader;
 
+import org.apache.commons.io.IOUtils;
 import org.bytedeco.javacpp.indexer.UByteIndexer;
 import org.bytedeco.javacv.Frame;
 import org.bytedeco.javacv.Java2DFrameConverter;
 import org.bytedeco.javacv.OpenCVFrameConverter;
-import org.datavec.api.util.ClassPathResource;
 import org.datavec.image.data.ImageWritable;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.io.ClassPathResource;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.util.Random;
 
 import static org.bytedeco.javacpp.lept.*;
@@ -304,6 +309,72 @@ public class TestNativeImageLoader {
         assertEquals(1, array1.size(1));
         assertEquals(h1, array1.size(2));
         assertEquals(w1, array1.size(3));
+    }
+
+    @Test
+    public void testBufferRealloc() throws Exception {
+        Nd4j.create(1);
+
+        Field f = NativeImageLoader.class.getDeclaredField("buffer");
+        f.setAccessible(true);
+
+        File f1 = new ClassPathResource("voc/2007/JPEGImages/000005.jpg").getFile();
+        File f2 = new ClassPathResource("voc/2007/JPEGImages/000007.jpg").getFile();
+
+        //Start with a large buffer
+        byte[] buffer = new byte[20*1024*1024];
+
+        NativeImageLoader loader = new NativeImageLoader(28, 28, 1);
+        f.set(loader, buffer);
+
+        INDArray img1LargeBuffer = loader.asMatrix(f1);
+        INDArray img2LargeBuffer = loader.asMatrix(f2);
+
+        //Check multiple reads:
+        INDArray img1LargeBuffer2 = loader.asMatrix(f1);
+        INDArray img1LargeBuffer3 = loader.asMatrix(f1);
+        assertEquals(img1LargeBuffer2, img1LargeBuffer3);
+
+        INDArray img2LargeBuffer2 = loader.asMatrix(f1);
+        INDArray img2LargeBuffer3 = loader.asMatrix(f1);
+        assertEquals(img2LargeBuffer2, img2LargeBuffer3);
+
+        //Clear the buffer and re-read:
+        f.set(loader, null);
+        INDArray img1NoBuffer1 = loader.asMatrix(f1);
+        INDArray img1NoBuffer2 = loader.asMatrix(f1);
+        assertEquals(img1LargeBuffer, img1NoBuffer1);
+        assertEquals(img1LargeBuffer, img1NoBuffer2);
+
+        f.set(loader, null);
+        INDArray img2NoBuffer1 = loader.asMatrix(f2);
+        INDArray img2NoBuffer2 = loader.asMatrix(f2);
+        assertEquals(img2LargeBuffer, img2NoBuffer1);
+        assertEquals(img2LargeBuffer, img2NoBuffer2);
+
+        //Assign much too small buffer:
+        buffer = new byte[10];
+        f.set(loader, buffer);
+        INDArray img1SmallBuffer1 = loader.asMatrix(f1);
+        INDArray img1SmallBuffer2 = loader.asMatrix(f1);
+        assertEquals(img1LargeBuffer, img1SmallBuffer1);
+        assertEquals(img1LargeBuffer, img1SmallBuffer2);
+
+        f.set(loader, buffer);
+        INDArray img2SmallBuffer1 = loader.asMatrix(f2);
+        INDArray img2SmallBuffer2 = loader.asMatrix(f2);
+        assertEquals(img2LargeBuffer, img2SmallBuffer1);
+        assertEquals(img2LargeBuffer, img2SmallBuffer2);
+
+        //Assign an exact buffer:
+        try(InputStream is = new FileInputStream(f1)){
+            byte[] temp = IOUtils.toByteArray(is);
+            buffer = new byte[temp.length];
+        }
+        f.set(loader, buffer);
+
+        INDArray img1ExactBuffer = loader.asMatrix(f1);
+        assertEquals(img1LargeBuffer, img1ExactBuffer);
     }
 
 }

--- a/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -313,8 +313,6 @@ public class TestNativeImageLoader {
 
     @Test
     public void testBufferRealloc() throws Exception {
-        Nd4j.create(1);
-
         Field f = NativeImageLoader.class.getDeclaredField("buffer");
         f.setAccessible(true);
 


### PR DESCRIPTION
***WIP DO NOT MERGE***
Fixes: https://github.com/deeplearning4j/DataVec/issues/571

All tests pass, good to go except for loading issue noted below (which should be resolved first).

@saudet without adding an Nd4j.create(1) at the top of the test (and 1 or 2 others now) I'm getting the following (when the tests are run in isolation):
```
java.lang.RuntimeException: No native JavaCPP library in memory. (Has Loader.load() been called?)
	at org.bytedeco.javacpp.BytePointer.<init>(BytePointer.java:103)
	at org.datavec.image.loader.NativeImageLoader.asMatrix(NativeImageLoader.java:211)
	at org.datavec.image.loader.NativeImageLoader.asMatrix(NativeImageLoader.java:202)
	at org.datavec.image.loader.TestNativeImageLoader.testBufferRealloc(TestNativeImageLoader.java:330)
...
Caused by: java.lang.UnsatisfiedLinkError: org.bytedeco.javacpp.BytePointer.allocateArray(J)V
	at org.bytedeco.javacpp.BytePointer.allocateArray(Native Method)
	at org.bytedeco.javacpp.BytePointer.<init>(BytePointer.java:98)
	... 25 more
```

What's the best workaround/solution here?