### PR TITLE
Remove no longer needed dependency on datavec-local.

### DIFF
--- a/datavec-spark-inference-parent/datavec-spark-inference-server/pom.xml
+++ b/datavec-spark-inference-parent/datavec-spark-inference-server/pom.xml
@@ -94,11 +94,6 @@
             <artifactId>datavec-data-image</artifactId>
             <version>${parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.datavec</groupId>
-            <artifactId>datavec-local</artifactId>
-            <version>${nd4j.version}</version>
-        </dependency>
 
     </dependencies>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

datavec-local isn't needed anymore with the spark inference server and brings in dependencies on arrow that are disruptive.

## How was this patch tested?

I verified that all inference server tests pass on my machine.
